### PR TITLE
Fix login session flow

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ShoppingBag, Package, DollarSign, TrendingUp, User, AlertTriangle } from "lucide-react"
 import { ref, onValue } from "firebase/database"
 import { database } from "@/lib/firebase"
+import { getAuth } from "firebase/auth"
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
@@ -76,20 +77,36 @@ export default function Dashboard() {
   const [dailySalesData, setDailySalesData] = useState<Sale[]>([]);
 
   useEffect(() => {
-    const storedUser = localStorage.getItem("user")
+    const auth = getAuth();
+
+    if (auth.currentUser) {
+      const role = auth.currentUser.email?.endsWith("@admin.com")
+        ? "admin"
+        : "moderator";
+      const currentUser = {
+        username: auth.currentUser.email || "",
+        role,
+      };
+      setUser(currentUser);
+      localStorage.setItem("user", JSON.stringify(currentUser));
+      setIsLoading(false);
+      return;
+    }
+
+    const storedUser = localStorage.getItem("user");
     if (!storedUser) {
-      router.push("/")
-      return
+      router.push("/");
+      return;
     }
 
     try {
-      const parsedUser = JSON.parse(storedUser)
-      setUser(parsedUser)
+      const parsedUser = JSON.parse(storedUser);
+      setUser(parsedUser);
     } catch (e) {
-      localStorage.removeItem("user")
-      router.push("/")
+      localStorage.removeItem("user");
+      router.push("/");
     } finally {
-        setIsLoading(false)
+      setIsLoading(false);
     }
   }, [router])
 

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -23,9 +23,11 @@ export default function LoginForm() {
     setIsLoading(true)
 
     const auth = getAuth()
-    
+    const trimmedEmail = email.trim()
+    const trimmedPassword = password.trim()
+
     try {
-      await signInWithEmailAndPassword(auth, email, password)
+      await signInWithEmailAndPassword(auth, trimmedEmail, trimmedPassword)
       // --- CORRECCIÓN CLAVE ---
       // Se redirige directamente al dashboard. El layout se encargará de la carga.
       router.push("/dashboard")


### PR DESCRIPTION
## Summary
- verify auth state before using local storage on the dashboard page
- trim email and password before signing in

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688100b04f6c8326b62566e7c12b0aa3