### PR TITLE
Improve session persistence

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,26 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { getAuth } from "firebase/auth"
 import LoginForm from "@/components/login-form"
 
 export default function Home() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const auth = getAuth()
+    if (auth.currentUser) {
+      router.replace("/dashboard")
+      return
+    }
+
+    const storedUser = localStorage.getItem("user")
+    if (storedUser) {
+      router.replace("/dashboard")
+    }
+  }, [router])
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-slate-50 to-slate-100 p-4">
       <div className="w-full max-w-md">

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -8,7 +8,12 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { AlertCircle } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth"
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  setPersistence,
+  browserLocalPersistence,
+} from "firebase/auth"
 
 export default function LoginForm() {
   const router = useRouter()
@@ -27,9 +32,16 @@ export default function LoginForm() {
     const trimmedPassword = password.trim()
 
     try {
+      await setPersistence(auth, browserLocalPersistence)
       await signInWithEmailAndPassword(auth, trimmedEmail, trimmedPassword)
-      // --- CORRECCIÓN CLAVE ---
-      // Se redirige directamente al dashboard. El layout se encargará de la carga.
+
+      const currentUser = auth.currentUser
+      if (currentUser && currentUser.email) {
+        const role = currentUser.email.endsWith("@admin.com") ? "admin" : "moderator"
+        const userData = { username: currentUser.email, role }
+        localStorage.setItem("user", JSON.stringify(userData))
+      }
+
       router.push("/dashboard")
     } catch (authError: any) {
       console.error("Error de Firebase Auth:", authError)


### PR DESCRIPTION
## Summary
- keep user logged in on refresh
- store user info after login

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688149a72df48326b9e57445f73b5085