### PR TITLE
Fix dashboard reload login

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import { Inter } from "next/font/google"
 import { Toaster } from "@/components/ui/sonner" // Importa el Toaster de sonner
 import FirebaseProvider from "@/components/firebase-provider"
+import PathCleaner from "@/components/path-cleaner"
 import type { Metadata } from "next"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -21,6 +22,7 @@ export default function RootLayout({
     <html lang="es">
       <body className={inter.className}>
         <FirebaseProvider>
+          <PathCleaner />
           {children}
           {/* Este es el Toaster de sonner */}
           <Toaster position="top-right" richColors />

--- a/components/path-cleaner.tsx
+++ b/components/path-cleaner.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { getAuth } from "firebase/auth"
+
+export default function PathCleaner() {
+  const router = useRouter()
+  useEffect(() => {
+    const auth = getAuth()
+    const path = window.location.pathname
+    if (path.startsWith("/dashboard") && !auth.currentUser && !localStorage.getItem("user")) {
+      router.replace("/")
+    }
+  }, [router])
+  return null
+}


### PR DESCRIPTION
## Summary
- add PathCleaner component to force login route if the dashboard is refreshed without a session
- include PathCleaner in the root layout so that reloading `/dashboard` when not logged in redirects to `/`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815153cdfc83269c9d35883ad8d35f