### PR TITLE
Fix auth race resetting sessions

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -117,6 +117,16 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         localStorage.setItem("user", JSON.stringify(userData));
         setIsLoading(false);
       } else {
+        const storedUser = localStorage.getItem("user");
+        if (storedUser) {
+          try {
+            setUser(JSON.parse(storedUser));
+            setIsLoading(false);
+            return;
+          } catch {
+            localStorage.removeItem("user");
+          }
+        }
         localStorage.removeItem("user");
         router.push("/");
       }


### PR DESCRIPTION
## Summary
- keep local session if Firebase auth loads as `null`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815efc4b88832690280ddb557abb1e