### PR TITLE
Fix logout functionality

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -188,7 +188,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const handleLogout = async () => {
     const auth = getAuth();
     try {
+      localStorage.removeItem("user");
       await signOut(auth);
+      setUser(null);
+      router.push("/");
     } catch (error) {
       console.error("Error al cerrar sesión:", error);
     }


### PR DESCRIPTION
## Summary
- clear localStorage and redirect when user logs out

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824f4ac9f88326b2966ab137eafe74