### PR TITLE
Fix redirect after logout

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -128,6 +128,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           }
         }
         localStorage.removeItem("user");
+        setIsLoading(false);
         router.push("/");
       }
     });
@@ -210,6 +211,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     local1: 'Local 1',
     local2: 'Local 2'
   };
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      router.replace('/');
+    }
+  }, [isLoading, user, router]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- set loading state before redirecting on auth change
- add effect to redirect to login when user data is missing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688251bba6d4832694743fed4b733939