### PR TITLE
Fix login redirect loop

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { getAuth } from "firebase/auth"
+import { getAuth, onAuthStateChanged } from "firebase/auth"
 import LoginForm from "@/components/login-form"
 
 export default function Home() {
@@ -10,29 +10,15 @@ export default function Home() {
 
   useEffect(() => {
     const auth = getAuth()
-
-    // Si existe un usuario autenticado en Firebase, redirigir al dashboard
-    if (auth.currentUser) {
-      router.replace("/dashboard")
-      return
-    }
-
-    // Verificar usuario almacenado localmente
-    const storedUser = localStorage.getItem("user")
-    if (storedUser) {
-      try {
-        const parsedUser = JSON.parse(storedUser)
-
-        // Solo redirigir si los datos son válidos
-        if (parsedUser && parsedUser.username) {
-          router.replace("/dashboard")
-          return
-        }
-      } catch {
-        // Si los datos no son válidos, eliminarlos
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      if (firebaseUser) {
+        router.replace("/dashboard")
+      } else {
         localStorage.removeItem("user")
       }
-    }
+    })
+
+    return () => unsubscribe()
   }, [router])
 
   return (

--- a/components/path-cleaner.tsx
+++ b/components/path-cleaner.tsx
@@ -9,7 +9,8 @@ export default function PathCleaner() {
   useEffect(() => {
     const auth = getAuth()
     const path = window.location.pathname
-    if (path.startsWith("/dashboard") && !auth.currentUser && !localStorage.getItem("user")) {
+    if (path.startsWith("/dashboard") && !auth.currentUser) {
+      localStorage.removeItem("user")
       router.replace("/")
     }
   }, [router])


### PR DESCRIPTION
## Summary
- rely on Firebase's auth state to determine when to redirect to `/dashboard`
- clear stale user session and redirect from `/dashboard` if no Firebase user

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882738eb1288326b05886a71f63baeb