### PR TITLE
Fix login checks and dashboard access

### DIFF
--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -143,13 +143,29 @@ export default function InventoryPage() {
     editingProduct?.category === "Celulares Nuevos";
 
   useEffect(() => {
-    const storedUser = localStorage.getItem("user");
-    if (storedUser) {
+    const auth = getAuth();
+    if (auth.currentUser) {
+      const role = auth.currentUser.email?.endsWith("@admin.com")
+        ? "admin"
+        : "moderator";
+      const currentUser = {
+        username: auth.currentUser.email || "",
+        role,
+      };
+      setUser(currentUser);
+      localStorage.setItem("user", JSON.stringify(currentUser));
+    } else {
+      const storedUser = localStorage.getItem("user");
+      if (!storedUser) {
+        router.push("/");
+        return;
+      }
       try {
         setUser(JSON.parse(storedUser));
       } catch {
         localStorage.removeItem("user");
-        setUser(null);
+        router.push("/");
+        return;
       }
     }
 

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -11,6 +11,7 @@ import { Search, Calendar, ShoppingCart, DollarSign, User, Download, Eye } from 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ref, onValue } from "firebase/database"
 import { database } from "@/lib/firebase"
+import { getAuth } from "firebase/auth"
 import SaleDetailModal from "@/components/sale-detail-modal"
 
 // Interfaces
@@ -70,17 +71,25 @@ export default function SalesPage() {
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   useEffect(() => {
-    const storedUser = localStorage.getItem("user")
-    if (!storedUser) {
-      router.push("/")
-      return
-    }
-
-    try {
-      setUser(JSON.parse(storedUser))
-    } catch (e) {
-      localStorage.removeItem("user")
-      router.push("/")
+    const auth = getAuth();
+    if (auth.currentUser) {
+      const role = auth.currentUser.email?.endsWith("@admin.com") ? "admin" : "moderator";
+      const currentUser = { username: auth.currentUser.email || "", role };
+      setUser(currentUser);
+      localStorage.setItem("user", JSON.stringify(currentUser));
+    } else {
+      const storedUser = localStorage.getItem("user");
+      if (!storedUser) {
+        router.push("/");
+        return;
+      }
+      try {
+        setUser(JSON.parse(storedUser));
+      } catch (e) {
+        localStorage.removeItem("user");
+        router.push("/");
+        return;
+      }
     }
 
     const salesRef = ref(database, "sales")

--- a/components/path-cleaner.tsx
+++ b/components/path-cleaner.tsx
@@ -2,16 +2,25 @@
 
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { getAuth } from "firebase/auth"
+import { getAuth, onAuthStateChanged } from "firebase/auth"
 
 export default function PathCleaner() {
   const router = useRouter()
   useEffect(() => {
     const auth = getAuth()
     const path = window.location.pathname
-    if (path.startsWith("/dashboard") && !auth.currentUser && !localStorage.getItem("user")) {
-      router.replace("/")
-    }
+
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      if (
+        path.startsWith("/dashboard") &&
+        !firebaseUser &&
+        !localStorage.getItem("user")
+      ) {
+        router.replace("/")
+      }
+    })
+
+    return () => unsubscribe()
   }, [router])
   return null
 }


### PR DESCRIPTION
## Summary
- improve dashboard auth redirect logic
- validate Firebase session in inventory page
- validate Firebase session in sales page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688287d31858832690da74ef69e18e63