### PR TITLE
Handle reserved stock

### DIFF
--- a/app/dashboard/reserves/page.tsx
+++ b/app/dashboard/reserves/page.tsx
@@ -117,7 +117,7 @@ export default function ReservesPage() {
       const productRef = ref(database, `products/${reserve.productId}`)
       await update(productRef, {
         reserved: false,
-        stock: (reserve.productStock || 0) + 1,
+        stock: reserve.productStock || 0,
       })
       toast.success("Reserva cancelada correctamente")
     } catch (error) {

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -76,7 +76,13 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
         completedAt: new Date().toISOString(),
       });
 
-      // 3. Notificar al componente padre que la operación fue exitosa
+      // 3. Liberar el producto reservado
+      if (reserve.productId) {
+        const productRef = ref(database, `products/${reserve.productId}`);
+        await update(productRef, { reserved: false });
+      }
+
+      // 4. Notificar al componente padre que la operación fue exitosa
       onReserveCompleted();
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure reserved cancellations restore proper stock
- free product when completing reserve sale
- track reserve data in dashboard and finance pages
- include active reserves in product totals and cost calculations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839f8eb6c48326a2f65b56d056b4eb