### PR TITLE
Fix reserve quantity handling

### DIFF
--- a/app/dashboard/reserves/page.tsx
+++ b/app/dashboard/reserves/page.tsx
@@ -104,9 +104,11 @@ export default function ReservesPage() {
       })
 
       const productRef = ref(database, `products/${reserve.productId}`)
+      const productSnapshot = await get(productRef)
+      const currentStock = productSnapshot.exists() ? productSnapshot.val().stock || 0 : 0
       await update(productRef, {
         reserved: false,
-        stock: reserve.productStock || 0,
+        stock: currentStock + (reserve.quantity || 1),
       })
       toast.success("Reserva cancelada correctamente")
     } catch (error) {

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -27,6 +27,7 @@ export interface Reserve {
   productPrice?: number;
   productId?: string;
   productStock?: number;
+  quantity?: number;
   downPayment?: number;
   remainingAmount?: number;
   status: string;
@@ -60,7 +61,7 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
         items: [{
           productId: reserve.productId,
           productName: reserve.productName,
-          quantity: 1,
+          quantity: reserve.quantity || 1,
           price: reserve.productPrice,
         }],
         paymentMethod,

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -398,7 +398,10 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
       const currentStock = productSnapshot.val().stock || 0;
       if (currentStock <= 0) throw new Error('Sin stock disponible');
 
-      await update(productRef, { stock: currentStock - 1, reserved: true });
+      const newStock = currentStock - item.quantity;
+      if (newStock < 0) throw new Error('Stock insuficiente');
+
+      await update(productRef, { stock: newStock, reserved: true });
 
       const newReserveRef = push(ref(database, 'reserves'));
       const priceARS = convertPrice(item.price, usdRate) * item.quantity;
@@ -411,6 +414,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
         customerDni: customer.dni,
         productName: item.name,
         productId: item.id,
+        quantity: item.quantity,
         productPrice: priceARS,
         productStock: currentStock,
         downPayment: reserveAmount,


### PR DESCRIPTION
## Summary
- handle reserve operations with the quantity selected
- track quantity in reserve data and in sale completion
- restore quantity when cancelling a reserve

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a7a8443c8326b998a1933bc4f02e