### PR TITLE
Add accumulated points to PDF receipts

### DIFF
--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -559,8 +559,7 @@ export default function InventoryPage() {
                             />
                             {isMobile && (
                               <p className="text-xs text-muted-foreground pt-1">
-                                Mantén presionado para "Escanear texto" con la
-                                cámara.
+                                Mantén presionado para &quot;Escanear texto&quot; con la cámara.
                               </p>
                             )}
                           </div>
@@ -907,7 +906,7 @@ export default function InventoryPage() {
                       />
                       {isMobile && (
                         <p className="text-xs text-muted-foreground pt-1">
-                          Mantén presionado para "Escanear texto" con la cámara.
+                          Mantén presionado para &quot;Escanear texto&quot; con la cámara.
                         </p>
                       )}
                     </div>

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -64,6 +64,7 @@ interface Sale {
     usdRate: number;
     pointsUsed?: number;
     pointsEarned?: number;
+    pointsAccumulated?: number;
 }
 
 // Interfaz para los datos de la reserva
@@ -371,6 +372,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
         }
 
         const newSaleRef = push(ref(database, "sales"));
+        const updatedPoints = availablePoints - pointsToUse + pointsEarned;
         const saleData: Sale = {
             id: newSaleRef.key!,
             receiptNumber,
@@ -394,12 +396,12 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             usdRate,
             pointsUsed: pointsToUse,
             pointsEarned,
+            pointsAccumulated: updatedPoints,
         };
         await set(newSaleRef, saleData);
 
         if (customerId) {
             const customerRef = ref(database, `customers/${customerId}`);
-            const updatedPoints = availablePoints - pointsToUse + pointsEarned;
             await update(customerRef, { points: updatedPoints, lastPurchase: new Date().toISOString() });
             setAvailablePoints(updatedPoints);
         }

--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -32,6 +32,7 @@ interface Sale {
   usdRate?: number;
   tradeIn?: TradeIn;
   pointsEarned?: number;
+  pointsAccumulated?: number;
 }
 
 interface Repair {
@@ -231,6 +232,12 @@ const drawSalePdfContent = (page: any, saleData: Sale, fonts: Fonts) => {
     page.drawText(`Puntos sumados con esta compra: ${saleData.pointsEarned || 0}`, {
         x: positions.itemStartX,
         y: pointsY,
+        size: 10,
+        font: helveticaFont
+    });
+    page.drawText(`Puntos acumulados: ${saleData.pointsAccumulated || 0}`, {
+        x: positions.itemStartX,
+        y: pointsY - 12,
         size: 10,
         font: helveticaFont
     });


### PR DESCRIPTION
## Summary
- show client's accumulated points alongside earned points in sale PDF
- track updated points balance after each sale
- escape quotes in inventory page to satisfy lint

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890511f679483269ba096a07affea3d