### PR TITLE
Ajusta coordenadas de vencimiento en PDF de reservas y agrega teléfono de cliente

### DIFF
--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -77,6 +77,7 @@ interface Reserve {
     customerId: string;
     customerName: string;
     customerDni: string;
+    customerPhone: string;
     productName: string;
     productId: string;
     quantity: number;
@@ -491,6 +492,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             customerId: customerId!,
             customerName: customer.name,
             customerDni: customer.dni,
+            customerPhone: customer.phone,
             productName: item.name,
             productId: item.id,
             quantity: reservedQuantity,

--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -533,7 +533,7 @@ export const generateReserveReceiptPdf = async (reserveData: Reserve) => {
 
     if (pdfDoc.getPageCount() > 1) {
         const secondPage = pdfDoc.getPages()[1];
-        drawReservePdfContent(secondPage, reserveData, { helveticaFont, helveticaBold });
+        drawReservePdfContent(secondPage, reserveData, { helveticaFont, helveticaBold }, true);
     }
 
     const pdfBytes = await pdfDoc.save();
@@ -554,7 +554,7 @@ export const generateReserveReceiptPdf = async (reserveData: Reserve) => {
   }
 };
 
-const drawReservePdfContent = (page: any, reserve: Reserve, fonts: Fonts) => {
+const drawReservePdfContent = (page: any, reserve: Reserve, fonts: Fonts, isSecondPage = false) => {
     const { helveticaFont, helveticaBold } = fonts;
     const fromTop = (y: number) => page.getHeight() - y;
     const positions = {
@@ -569,8 +569,8 @@ const drawReservePdfContent = (page: any, reserve: Reserve, fonts: Fonts) => {
         total: { x: 436, y: fromTop(365) },
         entrega: { x: 436, y: fromTop(390) },
         saldo: { x: 436, y: fromTop(420) },
-        fechaRetiro1: { x: 137, y: fromTop(524) },
-        fechaRetiro2: { x: 340, y: fromTop(617) }
+        fechaRetiro1: { x: isSecondPage ? 133 : 137, y: fromTop(527) },
+        fechaRetiro2: { x: isSecondPage ? 336 : 340, y: fromTop(621) }
     };
 
     const formattedDate = reserve.date ? new Date(reserve.date).toLocaleDateString() : 'N/A';


### PR DESCRIPTION
## Resumen
- Actualiza la generación de PDFs de reserva para ajustar coordenadas de fechas de retiro en ambas hojas y mover columnas en la segunda hoja.
- Incluye el teléfono del cliente al registrar una reserva para que se imprima correctamente.

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d171cfcc8326bc6c059ac8ebc1fa