### PR TITLE
Add location-aware sales and PDF templates

### DIFF
--- a/app/dashboard/repairs/page.tsx
+++ b/app/dashboard/repairs/page.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner"
 import AddRepairForm from "@/components/add-repair-form"
 import RepairDetailModal from "@/components/repair-detail-modal"
 import { generateRepairReceiptPdf } from "@/lib/pdf-generator"
+import { useStore } from "@/hooks/use-store"
 
 // --- INTERFAZ UNIFICADA Y DEFINITIVA ---
 // Esta es la estructura de datos consistente que se usará en ambos componentes.
@@ -61,6 +62,7 @@ export default function RepairsPage() {
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
   const [selectedRepair, setSelectedRepair] = useState<Repair | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const { selectedStore } = useStore();
 
   useEffect(() => {
     setIsLoading(true);
@@ -143,7 +145,7 @@ export default function RepairsPage() {
       
       await set(newRepairRef, finalRepairData);
       
-      await generateRepairReceiptPdf(finalRepairData, customerData);
+      await generateRepairReceiptPdf(finalRepairData, customerData, selectedStore === 'local2' ? 'local2' : 'local1');
 
       toast.success("Reparación agregada correctamente.", { description: `Recibo N°: ${newReceiptNumber}` });
       setIsAddModalOpen(false);
@@ -152,7 +154,7 @@ export default function RepairsPage() {
       console.error("Error detallado al agregar reparación:", error);
       toast.error("Error al agregar la reparación.", { description: (error as Error).message });
     }
-  }, []);
+  }, [selectedStore]);
 
   const handleUpdateRepair = useCallback(async (repairId: string, updatedData: Partial<Repair>) => {
     try {

--- a/components/repair-detail-modal.tsx
+++ b/components/repair-detail-modal.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
 import { generateDeliveryReceiptPdf } from "@/lib/pdf-generator";
+import { useStore } from "@/hooks/use-store";
 
 // --- INTERFAZ UNIFICADA Y DEFINITIVA ---
 // Usando la misma estructura que la página principal para consistencia.
@@ -47,6 +48,7 @@ interface RepairDetailModalProps {
 
 export default function RepairDetailModal({ isOpen, onClose, repair, onUpdate }: RepairDetailModalProps) {
   const [editableRepair, setEditableRepair] = useState<Repair | null>(repair);
+  const { selectedStore } = useStore();
 
   useEffect(() => {
     if (repair) {
@@ -79,7 +81,7 @@ export default function RepairDetailModal({ isOpen, onClose, repair, onUpdate }:
 
     if (updatedData.status === 'delivered' && repair.status !== 'delivered') {
         const pdfDataForGeneration = { ...repair, ...updatedData };
-        await generateDeliveryReceiptPdf(pdfDataForGeneration);
+        await generateDeliveryReceiptPdf(pdfDataForGeneration, selectedStore === 'local2' ? 'local2' : 'local1');
     }
     onClose();
   }

--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -35,6 +35,7 @@ interface Sale {
   pointsEarned?: number;
   pointsAccumulated?: number;
   pointsPaused?: boolean;
+  store?: 'local1' | 'local2';
 }
 
 interface Repair {
@@ -51,6 +52,7 @@ interface Repair {
     customerName?: string;
     customerDni?: string;
     customerPhone?: string;
+    store?: 'local1' | 'local2';
 }
 
 interface Reserve {
@@ -69,6 +71,7 @@ interface Reserve {
     downPayment: number;
     remainingAmount: number;
     status: 'reserved' | 'completed' | 'cancelled';
+    store?: 'local1' | 'local2';
 }
 
 interface Customer {
@@ -130,11 +133,14 @@ export const generateSaleReceiptPdf = async (completedSale: Sale) => {
     const hasNewCellphone = completedSale.items?.some(
       item => (item.category || '').toLowerCase() === 'celulares nuevos'
     );
-    let pdfTemplatePath = hasNewCellphone ? 'templates/receipt_nuevos.pdf' : 'templates/factura.pdf';
+    const store = completedSale.store === 'local2' ? 'local2' : 'local1';
+    let pdfTemplateBase = hasNewCellphone ? 'templates/receipt_nuevos' : 'templates/factura';
+    let pdfTemplatePath = store === 'local2' ? `${pdfTemplateBase}2.pdf` : `${pdfTemplateBase}.pdf`;
     let pdfTemplateExists = await checkPdfExists(pdfTemplatePath);
 
     if (!pdfTemplateExists && hasNewCellphone) {
-      pdfTemplatePath = 'templates/factura.pdf';
+      pdfTemplateBase = 'templates/factura';
+      pdfTemplatePath = store === 'local2' ? `${pdfTemplateBase}2.pdf` : `${pdfTemplateBase}.pdf`;
       pdfTemplateExists = await checkPdfExists(pdfTemplatePath);
     }
 
@@ -284,7 +290,7 @@ const drawSalePdfContent = (page: any, saleData: Sale, fonts: Fonts) => {
 
 
 // --- Generador de PDF para Reparaciones (Presupuesto) ---
-export const generateRepairReceiptPdf = async (repairData: Repair, customerData: Customer) => {
+export const generateRepairReceiptPdf = async (repairData: Repair, customerData: Customer, store: 'local1' | 'local2' = 'local1') => {
   if (!repairData || !customerData) {
     toast.error("Error", { description: "No hay datos para generar el PDF de reparación." });
     return;
@@ -296,7 +302,7 @@ export const generateRepairReceiptPdf = async (repairData: Repair, customerData:
 
   try {
     let pdfDoc: PDFDocument;
-    const pdfTemplatePath = "templates/presupuesto.pdf";
+    const pdfTemplatePath = store === 'local2' ? "templates/presupuesto2.pdf" : "templates/presupuesto.pdf";
     const pdfTemplateExists = await checkPdfExists(pdfTemplatePath);
 
     if (pdfTemplateExists) {
@@ -388,7 +394,7 @@ const drawRepairPdfContent = (page: any, repair: Repair, customer: Customer, fon
 
 
 // --- Generador de PDF para Entregas ---
-export const generateDeliveryReceiptPdf = async (repairData: Repair) => {
+export const generateDeliveryReceiptPdf = async (repairData: Repair, store: 'local1' | 'local2' = 'local1') => {
   if (!repairData) {
     toast.error("Error", { description: "No hay datos para generar el comprobante de entrega." });
     return;
@@ -400,7 +406,7 @@ export const generateDeliveryReceiptPdf = async (repairData: Repair) => {
 
   try {
     let pdfDoc: PDFDocument;
-    const pdfTemplatePath = "templates/entrega.pdf";
+    const pdfTemplatePath = store === 'local2' ? "templates/entrega2.pdf" : "templates/entrega.pdf";
     const pdfTemplateExists = await checkPdfExists(pdfTemplatePath);
 
     if (pdfTemplateExists) {
@@ -506,7 +512,8 @@ export const generateReserveReceiptPdf = async (reserveData: Reserve) => {
 
   try {
     let pdfDoc: PDFDocument;
-    const pdfTemplatePath = "templates/reserve-template.pdf";
+    const store = reserveData.store === 'local2' ? 'local2' : 'local1';
+    const pdfTemplatePath = store === 'local2' ? "templates/reserve-template2.pdf" : "templates/reserve-template.pdf";
     const pdfTemplateExists = await checkPdfExists(pdfTemplatePath);
 
     if (pdfTemplateExists) {


### PR DESCRIPTION
## Summary
- require choosing a store before selling and block products from other locations
- generate sale and reserve records with store info and select matching PDF templates
- allow repair and delivery PDFs to use location-specific templates

## Testing
- `pnpm lint`
- `pnpm build` *(fails: ERROR GRAVE DE CONFIGURACIÓN DE FIREBASE: La variable de entorno NEXT_PUBLIC_FIREBASE_APIKEY no está definida en tu archivo .env.local.)*

------
https://chatgpt.com/codex/tasks/task_e_6890d81b34a0832687bc1142238cb61d