### PR TITLE
fix subtotal Y position on trade-in sale receipt

### DIFF
--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -206,7 +206,8 @@ const drawSalePdfContent = (page: any, saleData: Sale, fonts: Fonts) => {
         itemStartX: 65,
         imeiStartX: 280,
         priceStartX: 455,
-        subtotal: { x: 430, y: fromTop(hasItems ? 495 : 521) },
+        // El valor X permanece, se ajusta la posición Y del subtotal a 495
+        subtotal: { x: 430, y: 495 },
         parteDePago: { x: 430, y: fromTop(hasItems ? 475 : 501) },
         precioFinal: { x: 455, y: 290 },
     };


### PR DESCRIPTION
## Summary
- adjust subtotal Y position to 495 in sale receipt when trade-in is involved

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891172d59e48326bb7f97fdda134bd3