### PR TITLE
Use Firebase counters for receipt and reserve numbers

### DIFF
--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -398,7 +398,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             toast.info("Equipo recibido en parte de pago", { description: `Se agregó ${tradeInProduct.name} al inventario.` });
         }
 
-        const counterRef = ref(database, 'counters/saleNumber');
+        const counterRef = ref(database, 'counters/receiptNumber');
         const transactionResult = await runTransaction(counterRef, (currentData) => {
             if (currentData === null) {
                 return { value: 1, prefix: 'V-', lastUpdated: new Date().toISOString() };
@@ -529,7 +529,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             await update(productRef, { stock: newStock });
         }
 
-        const counterRef = ref(database, 'counters/saleNumber');
+        const counterRef = ref(database, 'counters/reserveNumber');
         const transactionResult = await runTransaction(counterRef, (currentData) => {
             if (currentData === null) {
                 return { value: 1, prefix: 'V-', lastUpdated: new Date().toISOString() };


### PR DESCRIPTION
## Summary
- change sales to use `counters/receiptNumber` from Realtime Database
- add dedicated `counters/reserveNumber` for deposit (seña) receipts

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689132e064c483269af8f6c67b3f1c78