### PR TITLE
feat: add data reset option and white chat background

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -268,6 +268,26 @@ export default function SettingsPage() {
     }
   };
 
+  const handleResetData = async () => {
+    const password = window.prompt('Ingrese la contraseña');
+    if (password !== 'Emachines 16') {
+      toast.error('Contraseña incorrecta');
+      return;
+    }
+    try {
+      await Promise.all([
+        remove(ref(database, 'sales')),
+        remove(ref(database, 'products')),
+        remove(ref(database, 'customers')),
+        remove(ref(database, 'inventory')),
+        set(ref(database, 'finances'), 0),
+      ]);
+      toast.success('Datos del sistema eliminados.');
+    } catch (error) {
+      toast.error('Error al eliminar los datos.');
+    }
+  };
+
   return (
     <DashboardLayout>
       <div className="p-6 space-y-8">
@@ -436,6 +456,15 @@ export default function SettingsPage() {
                           </div>)) : <p className="text-sm text-muted-foreground text-center py-10">No hay reglas de combos configuradas.</p>}
                   </ScrollArea>
                </div>
+            </CardContent>
+          </Card>
+          <Card className="md:col-span-2 lg:col-span-3">
+            <CardHeader>
+              <CardTitle>Restablecer Datos</CardTitle>
+              <CardDescription>Borra ventas, productos, clientes e inventario y reinicia las finanzas.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="destructive" onClick={handleResetData}>Borrar Todo</Button>
             </CardContent>
           </Card>
         </div>

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -200,7 +200,7 @@ export default function ChatWidget() {
   return (
     <div className="fixed bottom-4 right-4 z-50">
       {isOpen ? (
-        <Card className={cn("w-80 h-96 flex flex-col shadow-lg bg-black/80 backdrop-blur-sm border-border/50")}>
+        <Card className={cn("w-80 h-96 flex flex-col shadow-lg bg-white text-slate-900 border-border/50")}> 
           <CardHeader className="flex flex-row items-center justify-between p-4 border-b">
             <CardTitle className="text-lg">Chat Interno</CardTitle>
             <Button variant="ghost" size="icon" onClick={() => { setIsOpen(false); handleCancelRecording(); }}>


### PR DESCRIPTION
## Summary
- set chat widget window background to white for better contrast
- add settings control to wipe sales, products, customers and inventory after password confirmation

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689210b02f9c8326a69e04f70386674a