### PR TITLE
feat: convert reserves to usd

### DIFF
--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -94,6 +94,14 @@ const formatCurrencyForPdf = (amount: number | undefined | null): string => {
   return `$${roundedAmount.toLocaleString('es-AR')}`;
 };
 
+const formatUsdCurrencyForPdf = (amount: number | undefined | null): string => {
+  const numAmount = Number(amount || 0);
+  return `$${numAmount.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
 const formatDateForPdf = (dateString: string | undefined | null): string => {
     if (!dateString) return 'N/A';
     const date = new Date(dateString);
@@ -612,11 +620,11 @@ const drawReservePdfContent = (page: any, reserve: Reserve, fonts: Fonts, isSeco
     page.drawText(String(reserve.customerPhone || ''), { ...positions.celCliente, size: 10, font: helveticaFont });
 
     page.drawText(reserve.productName || 'Producto sin nombre', { x: positions.itemStartX, y: positions.itemStartY, size: 10, font: helveticaFont });
-    page.drawText(formatCurrencyForPdf(reserve.productPrice), { x: positions.priceStartX, y: positions.itemStartY, size: 10, font: helveticaFont });
-    
-    page.drawText(formatCurrencyForPdf(reserve.productPrice), { ...positions.total, size: 10, font: helveticaFont });
-    page.drawText(formatCurrencyForPdf(reserve.downPayment), { ...positions.entrega, size: 10, font: helveticaFont });
-    page.drawText(formatCurrencyForPdf(reserve.remainingAmount), { ...positions.saldo, size: 12, font: helveticaBold });
+    page.drawText(formatUsdCurrencyForPdf(reserve.productPrice), { x: positions.priceStartX, y: positions.itemStartY, size: 10, font: helveticaFont });
+
+    page.drawText(formatUsdCurrencyForPdf(reserve.productPrice), { ...positions.total, size: 10, font: helveticaFont });
+    page.drawText(formatUsdCurrencyForPdf(reserve.downPayment), { ...positions.entrega, size: 10, font: helveticaFont });
+    page.drawText(formatUsdCurrencyForPdf(reserve.remainingAmount), { ...positions.saldo, size: 12, font: helveticaBold });
 
     // Imprimir fecha de retiro
     page.drawText(formattedExpirationDate, { ...positions.fechaRetiro1, size: 12, font: helveticaFont });

--- a/lib/price-converter.ts
+++ b/lib/price-converter.ts
@@ -15,9 +15,26 @@ export const convertPrice = (price: number, usdRate: number): number => {
   if (price < USD_PRICE_THRESHOLD) {
     return price * usdRate;
   }
-  
+
   // De lo contrario, se asume que ya está en ARS y se devuelve tal cual.
   return price;
+};
+
+/**
+ * Convierte un precio a dólares estadounidenses (USD) si es necesario,
+ * basándose únicamente en el umbral de precio.
+ * @param price - El precio del producto.
+ * @param usdRate - La cotización actual del dólar.
+ * @returns El precio convertido a USD.
+ */
+export const convertPriceToUSD = (price: number, usdRate: number): number => {
+  // Si el precio es menor al umbral, se asume que ya está en USD y se devuelve.
+  if (price < USD_PRICE_THRESHOLD) {
+    return price;
+  }
+
+  // De lo contrario, se convierte de ARS a USD.
+  return price / usdRate;
 };
 
 /**
@@ -29,5 +46,17 @@ export const formatCurrency = (amount: number): string => {
   return new Intl.NumberFormat('es-AR', {
     style: 'currency',
     currency: 'ARS',
+  }).format(amount);
+};
+
+/**
+ * Formatea un número como una moneda en dólares estadounidenses.
+ * @param amount - El monto a formatear.
+ * @returns El monto formateado como string (ej. "$1,234.50").
+ */
+export const formatUsdCurrency = (amount: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
   }).format(amount);
 };


### PR DESCRIPTION
## Summary
- add usd conversion and formatting utilities
- store reserve amounts in USD and include product data
- restore full product info when cancelling reserves and update receipts

## Testing
- `pnpm lint`
- `pnpm build` *(fails: ERROR GRAVE DE CONFIGURACIÓN DE FIREBASE: La variable de entorno NEXT_PUBLIC_FIREBASE_APIKEY no está definida en tu archivo .env.local.)*


------
https://chatgpt.com/codex/tasks/task_e_68925aa0745c8326a8ab3e25f6a3798b