### PR TITLE
feat: mostrar detalles completos en venta rápida

### DIFF
--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -219,7 +219,22 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
                 ) : (
                   filteredProducts.map((p) => (
                     <TableRow key={p.id}>
-                      <TableCell>{p.name}</TableCell>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <p className="font-medium">{p.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {`Categoría: ${p.category || "N/A"} | Marca: ${p.brand || "N/A"} | Modelo: ${p.model || "N/A"}`}
+                          </p>
+                          {p.barcode && (
+                            <p className="text-xs text-muted-foreground">Código: {p.barcode}</p>
+                          )}
+                          {typeof p.price === "number" && (
+                            <p className="text-xs text-muted-foreground">
+                              Precio: ${Number(p.price).toFixed(2)}
+                            </p>
+                          )}
+                        </div>
+                      </TableCell>
                       <TableCell>{p.stock}</TableCell>
                       <TableCell className="text-right">
                         <Button variant="ghost" size="icon" onClick={() => addToCart(p)}>


### PR DESCRIPTION
## Summary
- muestra nombre, categoría, marca, modelo, código y precio de productos al buscarlos en venta rápida

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68951531a2708326bb9811846f6fae74