### PR TITLE
Include brand and model in quick sale titles

### DIFF
--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -85,7 +85,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
       if ((p.stock || 0) <= 0) return false;
       if (store !== "all" && p.store !== store) return false;
 
-      const searchable = `${(p.name || "")} ${(p.brand || "")} ${(p.model || "")} ${(p.category || "")} ${(p.barcode || "")}`.toLowerCase();
+      const searchable = `${(p.name || "")} ${(p.brand || "")} ${(p.model || "")} ${(p.barcode || "")}`.toLowerCase();
 
       return terms.every((t) => searchable.includes(t));
     });
@@ -221,9 +221,8 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
                     <TableRow key={p.id}>
                       <TableCell>
                         <div className="space-y-1">
-                          <p className="font-medium">{p.name}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {`Categoría: ${p.category || "N/A"} | Marca: ${p.brand || "N/A"} | Modelo: ${p.model || "N/A"}`}
+                          <p className="font-medium">
+                            {[p.name, p.brand, p.model].filter(Boolean).join(" ")}
                           </p>
                           {p.barcode && (
                             <p className="text-xs text-muted-foreground">Código: {p.barcode}</p>

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -311,7 +311,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
     const terms = productSearchTerm.toLowerCase().split(/\s+/).filter(Boolean);
     return allProducts.filter(
       (p) => {
-        const searchable = `${(p.name || "")} ${(p.category || "")} ${(p.brand || "")} ${(p.model || "")} ${(p.barcode || "")}`.toLowerCase();
+        const searchable = `${(p.name || "")} ${(p.brand || "")} ${(p.model || "")} ${(p.barcode || "")}`.toLowerCase();
         return (
           terms.every(t => searchable.includes(t)) &&
           p.stock > 0 &&
@@ -661,9 +661,8 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                     {searchedProducts.map(p => (
                         <div key={p.id} className="flex items-center justify-between p-2 hover:bg-accent cursor-pointer" onClick={() => handleAddProductToCart(p)}>
                             <div>
-                              <p className="font-medium">{p.name}</p>
-                              <p className="text-xs text-muted-foreground">
-                                {`Categoría: ${p.category || "N/A"} | Marca: ${p.brand || "N/A"} | Modelo: ${p.model || "N/A"}`}
+                              <p className="font-medium">
+                                {[p.name, p.brand, p.model].filter(Boolean).join(" ")}
                               </p>
                               <p className="text-xs text-muted-foreground">Stock: {p.stock}</p>
                             </div>


### PR DESCRIPTION
## Summary
- show product name, brand, and model in quick sale and sell product modals
- remove category from search filters

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689517b568448326a0fe221ec65001ef