### PR TITLE
Add gift button for cart items

### DIFF
--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -28,7 +28,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Search, Plus, Trash2, Loader2 } from "lucide-react";
+import { Search, Plus, Trash2, Loader2, Gift } from "lucide-react";
 import { toast } from "sonner";
 
 interface Product {
@@ -281,16 +281,29 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
                         />
                       </TableCell>
                       <TableCell>
-                        <Input
-                          type="number"
-                          value={item.price ?? 0}
-                          min={0}
-                          className="w-24"
-                          onChange={(e) => updatePrice(item.id, parseFloat(e.target.value) || 0)}
-                        />
+                        <div className="flex items-center gap-1">
+                          <Input
+                            type="number"
+                            value={item.price ?? 0}
+                            min={0}
+                            className="w-24"
+                            onChange={(e) => updatePrice(item.id, parseFloat(e.target.value) || 0)}
+                          />
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => updatePrice(item.id, 0)}
+                          >
+                            <Gift className="h-4 w-4" />
+                          </Button>
+                        </div>
                       </TableCell>
                       <TableCell className="text-right">
-                        ${((item.price || 0) * item.quantity).toFixed(2)}
+                        {item.price === 0 ? (
+                          <span className="font-bold text-green-600">Regalo</span>
+                        ) : (
+                          `$${((item.price || 0) * item.quantity).toFixed(2)}`
+                        )}
                       </TableCell>
                       <TableCell className="text-right">
                         <Button variant="ghost" size="icon" onClick={() => removeFromCart(item.id)}>

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -15,7 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Loader2, Search, FileText, Trash2, Plus, Minus, DollarSign, User, Phone, Mail, Calendar } from "lucide-react"
+import { Loader2, Search, FileText, Trash2, Plus, Minus, DollarSign, User, Phone, Mail, Calendar, Gift } from "lucide-react"
 import { toast } from "sonner"
 import { generateSaleReceiptPdf, generateReserveReceiptPdf } from "@/lib/pdf-generator"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -632,6 +632,14 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                                 value={item.price}
                                 onChange={(e) => handlePriceChange(item.id, Number(e.target.value))}
                               />
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-6 w-6"
+                                onClick={() => handlePriceChange(item.id, 0)}
+                              >
+                                <Gift className="h-4 w-4" />
+                              </Button>
                               {item.price === 0 ? (
                                 <span className="font-bold text-green-600">Regalo</span>
                               ) : (


### PR DESCRIPTION
## Summary
- Add gift button to sale modal cart items to set price to zero and mark as gift
- Add gift button and gift label to quick sale cart items

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68951a85d5c08326bc7410f6da54c36e