### PR TITLE
Considerar pérdidas en ventas y ajustar finanzas

### DIFF
--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -140,9 +140,12 @@ export default function ReportsPage() {
   const salesByPeriodChartData = useMemo<SalesByPeriodData[]>(() => {
     const data: { [key: string]: number } = {};
     filteredSales.forEach(sale => {
-        if (sale.date && sale.totalAmount) {
+        if (sale.date) {
             const date = new Date(sale.date).toLocaleDateString('es-AR', { day: '2-digit', month: '2-digit' });
-            data[date] = (data[date] || 0) + sale.totalAmount;
+            const amount = Array.isArray(sale.items)
+                ? sale.items.reduce((acc, item) => acc + Number(item.price || 0) * Number(item.quantity || 1), 0)
+                : Number(sale.totalAmount || 0);
+            data[date] = (data[date] || 0) + amount;
         }
     });
     return Object.entries(data).map(([name, ventas]) => ({ name, ventas })).reverse();


### PR DESCRIPTION
## Summary
- Calculate and display total products sold and net profit on the sales dashboard, accounting for gifted items
- Update finances dashboard to compute income, costs and profitability from itemized sales in Firebase
- Fix reports dashboard totals to aggregate sale amounts from individual items

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952cb349988326b2c2c2942f9a4db8