### PR TITLE
Fix sales stats initialization order

### DIFF
--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -115,13 +115,6 @@ export default function SalesPage() {
       unsubscribeProducts();
     };
   }, [authLoading, user]);
-
-  useEffect(() => {
-    if (sales.length > 0) {
-      calculateSalesStats(sales)
-    }
-  }, [sales, calculateSalesStats])
-
   const calculateSalesStats = useCallback((salesData: Sale[]) => {
     const now = new Date()
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
@@ -166,6 +159,12 @@ export default function SalesPage() {
     setTotalProducts(productTotal)
     setNetProfit(profit)
   }, [products])
+
+  useEffect(() => {
+    if (sales.length > 0) {
+      calculateSalesStats(sales)
+    }
+  }, [sales, calculateSalesStats])
 
   const filteredSales = sales.filter(
     (sale) =>


### PR DESCRIPTION
## Summary
- avoid ReferenceError in Sales dashboard by moving calculateSalesStats before hook usage

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68952ff29e9c8326b857668348d8aac9