### PR TITLE
feat: track and display losses

### DIFF
--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
-import { Search, Calendar, ShoppingCart, DollarSign, User, Download, Eye, Package, TrendingUp } from "lucide-react"
+import { Search, Calendar, ShoppingCart, DollarSign, User, Download, Eye, Package, TrendingUp, TrendingDown } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ref, onValue } from "firebase/database"
 import { database } from "@/lib/firebase"
@@ -69,6 +69,7 @@ export default function SalesPage() {
   const [topProduct, setTopProduct] = useState<TopProductType>({ name: "", count: 0 })
   const [totalProducts, setTotalProducts] = useState(0)
   const [netProfit, setNetProfit] = useState(0)
+  const [totalLoss, setTotalLoss] = useState(0)
   
   const [selectedSale, setSelectedSale] = useState<Sale | null>(null)
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
@@ -96,6 +97,7 @@ export default function SalesPage() {
         setTopProduct({ name: "", count: 0 });
         setTotalProducts(0);
         setNetProfit(0);
+        setTotalLoss(0);
       }
     });
 
@@ -130,6 +132,7 @@ export default function SalesPage() {
     const productCounts: Record<string, number> = {}
     let productTotal = 0
     let profit = 0
+    let loss = 0
 
     salesData.forEach((sale) => {
       if (Array.isArray(sale.items)) {
@@ -139,7 +142,11 @@ export default function SalesPage() {
           }
           productTotal += item.quantity
           const cost = products.find(p => p.id === item.productId)?.cost || 0
-          profit += (Number(item.price) - Number(cost)) * item.quantity
+          const itemProfit = (Number(item.price) - Number(cost)) * item.quantity
+          profit += itemProfit
+          if (itemProfit < 0) {
+            loss += Math.abs(itemProfit)
+          }
         })
       }
     })
@@ -158,6 +165,7 @@ export default function SalesPage() {
     setTopProduct({ name: topProductName, count: topCount })
     setTotalProducts(productTotal)
     setNetProfit(profit)
+    setTotalLoss(loss)
   }, [products])
 
   useEffect(() => {
@@ -202,7 +210,7 @@ export default function SalesPage() {
         </div>
 
         {user?.role === 'admin' && (
-          <div className="grid gap-4 md:grid-cols-5 mb-6">
+          <div className="grid gap-4 md:grid-cols-6 mb-6">
               <Card>
                   <CardHeader className="flex flex-row items-center justify-between pb-2">
                   <CardTitle className="text-sm font-medium">Ventas del Día</CardTitle>
@@ -251,6 +259,15 @@ export default function SalesPage() {
                   </CardHeader>
                   <CardContent>
                   <div className="text-2xl font-bold">${netProfit.toFixed(2)}</div>
+                  </CardContent>
+              </Card>
+              <Card>
+                  <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardTitle className="text-sm font-medium">Pérdidas</CardTitle>
+                  <TrendingDown className="h-4 w-4 text-muted-foreground" />
+                  </CardHeader>
+                  <CardContent>
+                  <div className="text-2xl font-bold">${totalLoss.toFixed(2)}</div>
                   </CardContent>
               </Card>
           </div>


### PR DESCRIPTION
## Summary
- track loss from sales below cost
- display total losses on sales dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689588a1fd24832699018cad2c89b566