### PR TITLE
feat: show more details in low stock table

### DIFF
--- a/app/dashboard/low-stock/page.tsx
+++ b/app/dashboard/low-stock/page.tsx
@@ -29,7 +29,9 @@ import {
 interface Product {
   id: string;
   name?: string;
+  brand?: string;
   category?: string;
+  model?: string;
   stock?: number;
   [key: string]: any;
 }
@@ -146,16 +148,20 @@ export default function LowStockPage() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Producto</TableHead>
+                <TableHead>Nombre</TableHead>
+                <TableHead>Marca</TableHead>
                 <TableHead>Categoría</TableHead>
+                <TableHead>Modelo</TableHead>
                 <TableHead className="text-right">Stock Actual</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {filteredProducts.map((p) => (
                 <TableRow key={p.id}>
-                  <TableCell className="font-medium">{p.name}</TableCell>
-                  <TableCell>{p.category}</TableCell>
+                  <TableCell className="font-medium">{p.name || "Sin nombre"}</TableCell>
+                  <TableCell>{p.brand || "N/A"}</TableCell>
+                  <TableCell>{p.category || "N/A"}</TableCell>
+                  <TableCell>{p.model || "N/A"}</TableCell>
                   <TableCell className="text-right">
                     <Badge variant="destructive">{p.stock}</Badge>
                   </TableCell>


### PR DESCRIPTION
## Summary
- display brand and model in low stock table alongside name and category
- add brand and model fields to low stock product type

## Testing
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68959cdb129483269dc5fb0c677d8a56