### PR TITLE
fix: avoid empty SelectItem value in low stock filter

### DIFF
--- a/app/dashboard/low-stock/page.tsx
+++ b/app/dashboard/low-stock/page.tsx
@@ -49,7 +49,7 @@ export default function LowStockPage() {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [searchTerm, setSearchTerm] = useState("");
   const [categories, setCategories] = useState<string[]>([]);
-  const [categoryFilter, setCategoryFilter] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("all");
 
   useEffect(() => {
     if (!user) return;
@@ -117,7 +117,7 @@ export default function LowStockPage() {
         const storeMatch =
           selectedStore === "all" || p.store === selectedStore;
         const categoryMatch =
-          categoryFilter ? p.category === categoryFilter : true;
+          categoryFilter === "all" ? true : p.category === categoryFilter;
         const terms = searchTerm
           .toLowerCase()
           .split(/\s+/)
@@ -207,7 +207,7 @@ export default function LowStockPage() {
                 <SelectValue placeholder="Todas" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Todas</SelectItem>
+                <SelectItem value="all">Todas</SelectItem>
                 {categories.map((cat) => (
                   <SelectItem key={cat} value={cat}>
                     {cat}


### PR DESCRIPTION
## Summary
- prevent empty value in low-stock category filter Select
- adjust filter logic to treat "all" category as no filter

## Testing
- `pnpm lint`
- `pnpm build` *(fails: ERROR GRAVE DE CONFIGURACIÓN DE FIREBASE: La variable de entorno NEXT_PUBLIC_FIREBASE_APIKEY no está definida en tu archivo .env.local.)*

------
https://chatgpt.com/codex/tasks/task_e_6895a0e86e608326b2a166c33719c463