### PR TITLE
Fix mobile inventory layout and menu issues

### DIFF
--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -432,15 +432,15 @@ export default function InventoryPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-6">
-        <div className="flex items-center justify-between mb-6">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-bold">Inventario</h1>
-          <div className="flex items-center gap-4">
-            <div className="relative">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <div className="relative w-full sm:w-auto">
               <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
                 type="search"
                 placeholder="Buscar productos..."
-                className="pl-8 w-[250px]"
+                className="w-full pl-8 sm:w-[250px]"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
@@ -456,6 +456,7 @@ export default function InventoryPage() {
                 }
                 setIsQuickSaleOpen(true);
               }}
+              className="w-full sm:w-auto"
             >
               <ShoppingCart className="mr-2 h-4 w-4" />
               Venta Rápida
@@ -463,7 +464,7 @@ export default function InventoryPage() {
             {user?.role === "admin" && (
               <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
                 <DialogTrigger asChild>
-                  <Button>
+                  <Button className="w-full sm:w-auto">
                     <Plus className="mr-2 h-4 w-4" />
                     Agregar Producto
                   </Button>

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
-import { Home, Package, ShoppingCart, Users, Wrench, ChevronDown, LayoutDashboard } from "lucide-react"
+import { Home, Package, ShoppingCart, Users, Wrench, ChevronDown, LayoutDashboard, AlertTriangle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -48,6 +48,7 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
 
   const mainRoutes = [
     { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, active: pathname === "/dashboard", role: ["admin", "moderator"] },
+    { href: "/dashboard/low-stock", label: "Bajo Stock", icon: AlertTriangle, active: pathname === "/dashboard/low-stock", role: ["admin", "moderator"] },
     { href: "/dashboard/sales", label: "Ventas", icon: ShoppingCart, active: pathname === "/dashboard/sales", role: ["admin", "moderator"] },
     { href: "/dashboard/repairs", label: "Reparaciones", icon: Wrench, active: pathname === "/dashboard/repairs", role: ["admin", "moderator"] },
     { href: "/dashboard/reserves", label: "Reservas", icon: ShoppingCart, active: pathname === "/dashboard/reserves", role: ["admin", "moderator"] },
@@ -84,7 +85,13 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
 
             {/* Menú desplegable para Inventario */}
             <Collapsible open={isInventoryOpen} onOpenChange={setIsInventoryOpen}>
-              <CollapsibleTrigger className="w-full">
+              <CollapsibleTrigger
+                className="w-full"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsInventoryOpen((prev) => !prev);
+                }}
+              >
                 <div className={cn(
                     "flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-slate-900 transition-all hover:bg-slate-100",
                     isInventoryOpen && "bg-slate-100",


### PR DESCRIPTION
## Summary
- Improve inventory page header layout for mobile
- Add low-stock section and keep menu open in mobile menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895a4d5e27483269aacc681ae12847b