### PR TITLE
Filter repairs by store and polish mobile dashboards

### DIFF
--- a/app/dashboard/finances/page.tsx
+++ b/app/dashboard/finances/page.tsx
@@ -405,7 +405,7 @@ export default function FinancesPage() {
         </div>
 
         <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-3 overflow-x-auto">
             <TabsTrigger value="overview">Resumen</TabsTrigger>
             <TabsTrigger value="products">Productos</TabsTrigger>
             <TabsTrigger value="reports">Reportes</TabsTrigger>
@@ -476,7 +476,7 @@ export default function FinancesPage() {
                 <CardTitle>Rentabilidad por Producto</CardTitle>
                 <CardDescription>Análisis de costos, precios y márgenes de ganancia por producto.</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="overflow-x-auto">
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/app/dashboard/repairs/page.tsx
+++ b/app/dashboard/repairs/page.tsx
@@ -37,6 +37,7 @@ interface Repair {
   deliveryReceiptNumber?: string;
   finalPrice?: number;
   technicianNotes?: string;
+  store?: string;
   [key: string]: any;
 }
 
@@ -142,6 +143,7 @@ export default function RepairsPage() {
           entryDate: new Date().toISOString(),
           createdAt: Date.now(),
           status: 'pending' as const,
+          store: selectedStore === 'all' ? 'local1' : selectedStore,
       };
       
       await set(newRepairRef, finalRepairData);
@@ -186,9 +188,11 @@ export default function RepairsPage() {
   }
 
   const filteredRepairs = repairs.filter(r =>
-    (r.customerName || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (r.productName || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (r.receiptNumber || "").toLowerCase().includes(searchTerm.toLowerCase())
+    (selectedStore === 'all' || r.store === selectedStore) && (
+      (r.customerName || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (r.productName || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (r.receiptNumber || "").toLowerCase().includes(searchTerm.toLowerCase())
+    )
   );
 
   return (
@@ -220,13 +224,13 @@ export default function RepairsPage() {
               <TableRow>
                 <TableHead>N° Recibo</TableHead>
                 <TableHead>Cliente</TableHead>
-              <TableHead>Equipo</TableHead>
-              <TableHead>Estado</TableHead>
-              <TableHead>Fecha de Ingreso</TableHead>
-              <TableHead>Precio Estimado</TableHead>
-              <TableHead className="text-right">Acciones</TableHead>
-            </TableRow>
-          </TableHeader>
+                <TableHead>Equipo</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead>Fecha de Ingreso</TableHead>
+                <TableHead>Precio Estimado</TableHead>
+                <TableHead className="text-right">Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
           <TableBody>
             {isLoading ? (
               <TableRow>

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -259,7 +259,7 @@ export default function ReportsPage() {
         </div>
 
         <Tabs defaultValue="sales" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 overflow-x-auto">
             <TabsTrigger value="sales">Ventas</TabsTrigger>
             <TabsTrigger value="inventory">Inventario</TabsTrigger>
             <TabsTrigger value="finances">Finanzas</TabsTrigger>
@@ -267,7 +267,7 @@ export default function ReportsPage() {
           </TabsList>
           <TabsContent value="sales" className="mt-6">
             <div className="grid gap-4 md:grid-cols-2">
-              <Card className="col-span-2">
+              <Card className="md:col-span-2">
                 <CardHeader>
                   <CardTitle>Ventas por Período</CardTitle>
                 </CardHeader>


### PR DESCRIPTION
## Summary
- show repairs only for the currently selected store
- tweak finances and reports pages for better mobile chart layouts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895aa7cb1c48326b938b6adb015e398