### PR TITLE
Remove duplicate Caja link and filter cash register by store

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -317,10 +317,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
               <NavItem href="/dashboard/sales" icon={ShoppingCart} label="Ventas" active={pathname === "/dashboard/sales"} />
 
-              {user?.role === 'admin' && (
-                <NavItem href="/dashboard/caja" icon={Wallet} label="Caja" active={pathname === "/dashboard/caja"} />
-              )}
-
               <Collapsible open={isReservesOpen} onOpenChange={setIsReservesOpen} className="w-full">
                   <NavItem icon={ShoppingCart} label="Reservas" active={pathname.startsWith("/dashboard/reserves")} isCollapsible alert={expiringReserves}>
                       <ChevronDown className={cn("h-4 w-4 shrink-0 transition-transform", isReservesOpen && "rotate-180")}/>


### PR DESCRIPTION
## Summary
- remove Caja entry from sidebar layout
- ensure Caja page filters sales by selected store and records store on close

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0b5a153c8326a059ccdc658d41cf