### PR TITLE
Store daily cash closure details and add closure history page

### DIFF
--- a/app/dashboard/caja/cierres/page.tsx
+++ b/app/dashboard/caja/cierres/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ref, onValue } from "firebase/database";
+import DashboardLayout from "@/components/dashboard-layout";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { database } from "@/lib/firebase";
+import { useAuth } from "@/hooks/use-auth";
+
+interface SaleItem {
+  productId: string;
+  productName?: string;
+  quantity: number;
+  price: number;
+}
+
+interface Sale {
+  id: string;
+  items: SaleItem[];
+}
+
+interface Closure {
+  id: string;
+  timestamp: number;
+  store?: string;
+  cantidadProductosVendidos: number;
+  dineroTotal: number;
+  dineroTotalEfectivo: number;
+  dineroTotalBanco: number;
+  gananciasLimpias: number;
+  cantidadCelularesVendidos: number;
+  dineroTotalUSD: number;
+  gananciasLimpiasUSD: number;
+  dineroTotalEfectivoUSD: number;
+  dineroTotalBancoUSD: number;
+  sales?: Sale[];
+}
+
+export default function CashClosuresPage() {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+  const [closures, setClosures] = useState<Closure[]>([]);
+  const [filterDate, setFilterDate] = useState<string>("");
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.push("/");
+      return;
+    }
+    if (user.role !== "admin") {
+      router.push("/dashboard");
+      return;
+    }
+
+    const closuresRef = ref(database, "cashClosures");
+    const unsubscribe = onValue(closuresRef, (snapshot) => {
+      const data: Closure[] = [];
+      snapshot.forEach((child) => {
+        data.push({ id: child.key!, ...child.val() });
+      });
+      setClosures(data);
+    });
+
+    return () => unsubscribe();
+  }, [authLoading, user, router]);
+
+  const filtered = filterDate
+    ? closures.filter(
+        (c) =>
+          new Date(c.timestamp).toISOString().slice(0, 10) === filterDate
+      )
+    : closures;
+
+  return (
+    <DashboardLayout title="Cierres de Caja">
+      <Input
+        type="date"
+        value={filterDate}
+        onChange={(e) => setFilterDate(e.target.value)}
+        className="mb-4 w-fit"
+      />
+      <div className="space-y-4">
+        {filtered.map((c) => (
+          <Card key={c.id}>
+            <CardHeader>
+              <CardTitle>
+                {new Date(c.timestamp).toLocaleDateString()}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p>Productos vendidos: {c.cantidadProductosVendidos}</p>
+              <p>Dinero total ARS: ${c.dineroTotal.toFixed(2)}</p>
+              <p>Dinero total USD: ${c.dineroTotalUSD.toFixed(2)}</p>
+              <details className="mt-2">
+                <summary>Ver detalles</summary>
+                {c.sales?.map((sale) => (
+                  <div key={sale.id} className="ml-4 mt-2">
+                    {sale.items?.map((item, idx) => (
+                      <div key={idx} className="text-sm">
+                        {item.productName || item.productId} - {item.quantity} x ${
+                          item.price
+                        }
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </details>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </DashboardLayout>
+  );
+}
+

--- a/app/dashboard/caja/page.tsx
+++ b/app/dashboard/caja/page.tsx
@@ -100,11 +100,17 @@ export default function CajaPage() {
     };
   }, [authLoading, user, router, selectedStore]);
 
+  const filteredSales = useMemo(() =>
+    sales.filter(
+      (s) =>
+        new Date(s.date).getTime() > lastClosure &&
+        (selectedStore === 'all' || s.store === selectedStore)
+    ),
+    [sales, lastClosure, selectedStore]
+  );
+
   const metrics = useMemo(() => {
-    const filtered = sales.filter(s =>
-      new Date(s.date).getTime() > lastClosure &&
-      (selectedStore === 'all' || s.store === selectedStore)
-    );
+    const filtered = filteredSales;
     let accessorySales = 0;
     let productsNoPhones = 0;
     let newPhones = 0;
@@ -212,7 +218,7 @@ export default function CajaPage() {
       cellphonesBankARS: cellBankARS,
       cellphonesBankUSD: cellBankUSD,
     };
-  }, [sales, products, lastClosure, selectedStore]);
+  }, [filteredSales, products, selectedStore]);
 
   const handleCloseCash = async () => {
     const summary = {
@@ -230,7 +236,7 @@ export default function CajaPage() {
       store: selectedStore,
     };
     try {
-      await push(ref(database, 'cashClosures'), summary);
+      await push(ref(database, 'cashClosures'), { ...summary, sales: filteredSales });
       setLastClosure(Date.now());
       setSales([]);
       const text = `cantidad de productos vendidos: ${summary.cantidadProductosVendidos}\n` +


### PR DESCRIPTION
## Summary
- Track daily sales filtered after last closure and store them alongside cash closure summaries
- Add admin page to review past cash closures by date with itemized sale details

## Testing
- `pnpm lint` *(fails: React Hook dependency warning in add-repair-form.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e02a1908326b141ab0558bffe5c