### PR TITLE
fix: ensure cash closure and add back navigation

### DIFF
--- a/app/dashboard/caja/cierres/page.tsx
+++ b/app/dashboard/caja/cierres/page.tsx
@@ -111,12 +111,17 @@ export default function CashClosuresPage() {
 
   return (
     <DashboardLayout title="Cierres de Caja">
-      <Input
-        type="date"
-        value={filterDate}
-        onChange={(e) => setFilterDate(e.target.value)}
-        className="mb-4 w-fit"
-      />
+      <div className="mb-4 flex items-center gap-2">
+        <Button variant="secondary" onClick={() => router.back()}>
+          Volver
+        </Button>
+        <Input
+          type="date"
+          value={filterDate}
+          onChange={(e) => setFilterDate(e.target.value)}
+          className="w-fit"
+        />
+      </div>
       <div className="space-y-4">
         {filtered.map((c) => (
           <Card key={c.id}>

--- a/app/dashboard/caja/page.tsx
+++ b/app/dashboard/caja/page.tsx
@@ -16,10 +16,11 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Package, Smartphone, DollarSign, Wallet, CreditCard } from "lucide-react";
-import { ref, onValue, push, set } from "firebase/database";
+import { ref, onValue, push } from "firebase/database";
 import { database } from "@/lib/firebase";
 import { useAuth } from "@/hooks/use-auth";
 import { useStore } from "@/hooks/use-store";
+import { toast } from "sonner";
 
 interface SaleItem {
   productId: string;
@@ -280,15 +281,19 @@ export default function CajaPage() {
       note,
     };
     try {
-      const closureRef = push(ref(database, 'cashClosures'));
-      await set(closureRef, { ...summary, sales: filteredSales });
+      await push(ref(database, "cashClosures"), {
+        ...summary,
+        sales: filteredSales,
+      });
       generatePDF(summary);
       setLastClosure(summary.timestamp);
       setSales([]);
       setNote("");
       setDialogOpen(false);
+      toast.success("Caja cerrada correctamente");
     } catch (e) {
-      console.error('Error closing cash register', e);
+      console.error("Error closing cash register", e);
+      toast.error("Error al cerrar la caja");
     }
   };
 


### PR DESCRIPTION
## Summary
- improve cash closing logic with success and error feedback
- allow returning from previous cash closures list

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3dd65888832689c7976105357e71