### PR TITLE
Mantener accesorios al agotarse y contar reservados

### DIFF
--- a/app/dashboard/finances/page.tsx
+++ b/app/dashboard/finances/page.tsx
@@ -256,15 +256,16 @@ export default function FinancesPage() {
     const activeReserves = reservesByStore.filter(r => r.status === "reserved");
     activeReserves.forEach(reserve => {
         const prod = productMap.get(reserve.productId || "");
-        if (!prod) return;
-        const cost = Number(prod.cost) || 0;
-        const category = prod.category;
+        const category = prod?.category || reserve.productData?.category;
+        const cost = prod?.cost ?? reserve.productData?.cost ?? 0;
+        const quantity = reserve.quantity || 1;
+        if (!category) return;
         if (category === "Celulares Nuevos" || category === "Celulares Usados") {
-            deviceCount += 1;
-            deviceTotalCost += cost;
+            deviceCount += quantity;
+            deviceTotalCost += cost * quantity;
         } else {
-            accessoryCount += 1;
-            accessoryTotalCost += cost;
+            accessoryCount += quantity;
+            accessoryTotalCost += cost * quantity;
         }
     });
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -109,7 +109,9 @@ export default function Dashboard() {
             });
         }
         
-        const activeReserves = reserves.filter(r => r.status === "reserved").length
+        const activeReserves = reserves
+          .filter(r => r.status === "reserved")
+          .reduce((sum, r) => sum + (r.quantity || 1), 0)
         setDashboardData((prev) => ({
           ...prev,
           totalProducts:
@@ -126,7 +128,9 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (products.length === 0 && reserves.length === 0) return;
-    const activeReserves = reserves.filter(r => r.status === "reserved").length;
+    const activeReserves = reserves
+      .filter(r => r.status === "reserved")
+      .reduce((sum, r) => sum + (r.quantity || 1), 0);
     setDashboardData((prev) => ({
       ...prev,
       totalProducts:

--- a/app/dashboard/reserves/page.tsx
+++ b/app/dashboard/reserves/page.tsx
@@ -87,10 +87,18 @@ export default function ReservesPage() {
     const threeDaysFromNow = new Date();
     threeDaysFromNow.setDate(now.getDate() + 3);
 
-    const active = reservesData.filter(r => r.status === "reserved").length;
-    const expiringSoon = reservesData.filter(r => r.status === "reserved" && r.expirationDate && new Date(r.expirationDate) <= threeDaysFromNow).length;
-    const completed = reservesData.filter(r => r.status === "completed").length;
-    const cancelled = reservesData.filter(r => r.status === "cancelled").length;
+    const active = reservesData
+      .filter(r => r.status === "reserved")
+      .reduce((sum, r) => sum + (r.quantity || 1), 0);
+    const expiringSoon = reservesData
+      .filter(r => r.status === "reserved" && r.expirationDate && new Date(r.expirationDate) <= threeDaysFromNow)
+      .reduce((sum, r) => sum + (r.quantity || 1), 0);
+    const completed = reservesData
+      .filter(r => r.status === "completed")
+      .reduce((sum, r) => sum + (r.quantity || 1), 0);
+    const cancelled = reservesData
+      .filter(r => r.status === "cancelled")
+      .reduce((sum, r) => sum + (r.quantity || 1), 0);
 
     setReserveStats({ active, expiringSoon, completed, cancelled });
   };

--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -166,10 +166,16 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
         const productRef = ref(database, `products/${item.id}`);
         const snap = await get(productRef);
         if (!snap.exists()) continue;
-        const currentStock = snap.val().stock || 0;
+        const productData = snap.val();
+        const currentStock = productData.stock || 0;
         const newStock = currentStock - item.quantity;
         if (newStock <= 0) {
-          await remove(productRef);
+          const category = productData.category;
+          if (category === "Celulares Nuevos" || category === "Celulares Usados") {
+            await remove(productRef);
+          } else {
+            await update(productRef, { stock: 0 });
+          }
         } else {
           await update(productRef, { stock: newStock });
         }

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -393,7 +393,8 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             const productRef = ref(database, `products/${item.id}`);
             const productSnapshot = await get(productRef);
             if (productSnapshot.exists()) {
-                const currentStock = productSnapshot.val().stock || 0;
+                const productData = productSnapshot.val();
+                const currentStock = productData.stock || 0;
                 const newStock = currentStock - item.quantity;
 
                 if (newStock < 0) {
@@ -401,7 +402,12 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                 }
 
                 if (newStock <= 0) {
-                    await remove(productRef);
+                    const category = productData.category;
+                    if (category === "Celulares Nuevos" || category === "Celulares Usados") {
+                        await remove(productRef);
+                    } else {
+                        await update(productRef, { stock: 0 });
+                    }
                 } else {
                     await update(productRef, { stock: newStock });
                 }
@@ -547,7 +553,8 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
         const productSnapshot = await get(productRef);
         if (!productSnapshot.exists()) throw new Error('Producto no encontrado');
         
-        const currentStock = productSnapshot.val().stock || 0;
+        const productData = productSnapshot.val();
+        const currentStock = productData.stock || 0;
         const reservedQuantity = item.quantity;
 
         if (currentStock < reservedQuantity) {
@@ -556,7 +563,12 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
 
         const newStock = currentStock - reservedQuantity;
         if (newStock <= 0) {
-            await remove(productRef);
+            const category = productData.category;
+            if (category === "Celulares Nuevos" || category === "Celulares Usados") {
+                await remove(productRef);
+            } else {
+                await update(productRef, { stock: 0 });
+            }
         } else {
             await update(productRef, { stock: newStock });
         }


### PR DESCRIPTION
## Resumen
- Evitar eliminar accesorios al venderse o reservarse; ahora solo se remueven celulares y los accesorios quedan con stock 0.
- Las ventas rápidas y reservas consideran la categoría para decidir si borrar el producto.
- El dashboard y finanzas suman la cantidad de equipos reservados a los totales de stock.
- Las estadísticas de reservas contabilizan la cantidad de productos en cada estado.

## Pruebas
- `npm test` *(falla: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c36f92e88326a8648739642ee33b