### PR TITLE
Ensure sale records include product cost

### DIFF
--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -28,6 +28,8 @@ interface SaleItem {
   price: number;
   currency: 'USD' | 'ARS';
   category?: string;
+  cost?: number;
+  provider?: string;
 }
 
 interface Sale {
@@ -172,9 +174,11 @@ export default function SalesPage() {
             productCounts[item.productName] = (productCounts[item.productName] || 0) + item.quantity
           }
           productTotal += item.quantity
-          const cost = products.find(p => p.id === item.productId)?.cost || 0
+          const product = products.find(p => p.id === item.productId)
+          const cost = product?.cost ?? item.cost ?? 0
+          const unitPrice = Number(item.price) * (item.currency === 'USD' ? (sale.usdRate || 1) : 1)
           costTotal += Number(cost) * item.quantity
-          const itemProfit = (Number(item.price) - Number(cost)) * item.quantity
+          const itemProfit = (unitPrice - Number(cost)) * item.quantity
           if (itemProfit < 0) {
             loss += Math.abs(itemProfit)
           }
@@ -220,7 +224,7 @@ export default function SalesPage() {
   const calculateNetSale = useCallback((sale: Sale) => {
     return (sale.items || []).reduce((sum, item) => {
       const product = products.find(p => p.id === item.productId)
-      const unitCost = Number(product?.cost || 0)
+      const unitCost = Number(product?.cost ?? item.cost ?? 0)
       const unitPrice = Number(item.price) * (item.currency === 'USD' ? (sale.usdRate || 1) : 1)
       return sum + (unitPrice - unitCost) * item.quantity
     }, 0)

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -89,6 +89,8 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
           productName: reserve.productName,
           quantity: reserve.quantity || 1,
           price: (reserve.productPrice || 0) * usdRate,
+          cost: Number(reserve.productData?.cost || 0),
+          provider: reserve.productData?.provider || null,
         }],
         paymentMethod,
         ...(paymentMethod === "multiple" ? { cashAmount, transferAmount, cardAmount } : {}),

--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -194,6 +194,8 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
           quantity: item.quantity,
           price: item.price || 0,
           currency: "ARS",
+          cost: Number(item.cost || 0),
+          provider: item.provider || null,
         })),
         totalAmount,
         paymentMethod,

--- a/components/sale-detail-modal.tsx
+++ b/components/sale-detail-modal.tsx
@@ -34,6 +34,8 @@ interface SaleItem {
   price: number
   currency: 'USD' | 'ARS'
   category?: string
+  cost?: number
+  provider?: string
 }
 
 interface Product {
@@ -90,7 +92,8 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
                 {sale.items.map((item, index) => {
                   const productInfo = productsMap.get(item.productId)
                   const unitPriceInARS = item.price * (item.currency === 'USD' ? (sale.usdRate || 1) : 1)
-                  const unitCost = productInfo?.cost || 0
+                  const unitCost = productInfo?.cost ?? item.cost ?? 0
+                  const provider = productInfo?.provider || item.provider || 'N/A'
                   const profitPerUnit = unitPriceInARS - unitCost
                   const subtotal = unitPriceInARS * item.quantity
                   const totalProfit = profitPerUnit * item.quantity
@@ -106,7 +109,7 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
                           ${totalProfit.toFixed(2)}
                         </TableCell>
                       )}
-                      {user.role === 'admin' && <TableCell>{productInfo?.provider || 'N/A'}</TableCell>}
+                      {user.role === 'admin' && <TableCell>{provider}</TableCell>}
                       <TableCell className="text-right">${subtotal.toFixed(2)}</TableCell>
                     </TableRow>
                   )

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -37,6 +37,7 @@ interface CartProduct {
   brand?: string;
   provider?: string;
   store?: "local1" | "local2";
+  cost?: number;
 }
 
 interface BundleRule {
@@ -473,6 +474,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                 barcode: item.barcode || null,
                 provider: item.provider || null,
                 category: item.category || null,
+                cost: item.cost ?? 0,
             })),
             paymentMethod,
             ...(paymentMethod === "multiple" ? { cashAmount, transferAmount, cardAmount } : {}),


### PR DESCRIPTION
## Summary
- store item cost and provider when saving sales and completed reserves
- show unit cost in sale details even if original product is missing
- use stored cost for sales stats and net calculations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60ad4a3a88326a61344ab25e585be