### PR TITLE
Show device identifiers in sales and enable moderator cash close

### DIFF
--- a/app/dashboard/caja/page.tsx
+++ b/app/dashboard/caja/page.tsx
@@ -66,7 +66,7 @@ export default function CajaPage() {
       router.push("/");
       return;
     }
-    if (user.role !== 'admin') {
+    if (user.role !== 'admin' && user.role !== 'moderator') {
       router.push('/dashboard');
       return;
     }
@@ -395,24 +395,28 @@ export default function CajaPage() {
             <div className="text-2xl font-bold">${metrics.totalMoneyUSD.toFixed(2)}</div>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">Ganancias Limpias (ARS)</CardTitle>
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">${metrics.profitARS.toFixed(2)}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium">Ganancias Limpias (USD)</CardTitle>
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">${metrics.profitUSD.toFixed(2)}</div>
-          </CardContent>
-        </Card>
+        {user?.role === 'admin' && (
+          <>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium">Ganancias Limpias (ARS)</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${metrics.profitARS.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium">Ganancias Limpias (USD)</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${metrics.profitUSD.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+          </>
+        )}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Efectivo (ARS)</CardTitle>

--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -43,6 +43,7 @@ import {
   ShoppingCart,
   Barcode,
   User,
+  Wallet,
 } from "lucide-react";
 import { ref, onValue, set, push, remove, update } from "firebase/database";
 import { database } from "@/lib/firebase";
@@ -477,6 +478,16 @@ export default function InventoryPage() {
               <ShoppingCart className="mr-2 h-4 w-4" />
               Venta Rápida
             </Button>
+            {user?.role === "moderator" && (
+              <Button
+                onClick={() => router.push("/dashboard/caja")}
+                className="w-full sm:w-auto"
+                variant="secondary"
+              >
+                <Wallet className="mr-2 h-4 w-4" />
+                Cerrar Caja
+              </Button>
+            )}
             {user?.role === "admin" && (
               <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
                 <DialogTrigger asChild>

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -31,6 +31,8 @@ interface SaleItem {
   category?: string;
   cost?: number;
   provider?: string;
+  imei?: string;
+  barcode?: string;
 }
 
 interface Sale {
@@ -398,7 +400,13 @@ export default function SalesPage() {
                       </TableCell>
                       {user?.role === 'admin' && <TableCell>{sale.customerDni}</TableCell>}
                       <TableCell>
-                        {(sale.items || []).map(item => `${item.quantity}x ${item.productName}`).join(', ')}
+                        {(sale.items || []).map(item => {
+                          const details = [] as string[]
+                          if (item.imei) details.push(`IMEI: ${item.imei}`)
+                          if (item.barcode) details.push(`S/N: ${item.barcode}`)
+                          const info = details.length ? ` (${details.join(' / ')})` : ''
+                          return `${item.quantity}x ${item.productName}${info}`
+                        }).join(', ')}
                       </TableCell>
                       <TableCell>${Number(sale.totalAmount).toFixed(2)}</TableCell>
                       <TableCell>{sale.usdRate ? sale.usdRate.toFixed(2) : '-'}</TableCell>

--- a/components/sale-detail-modal.tsx
+++ b/components/sale-detail-modal.tsx
@@ -36,6 +36,8 @@ interface SaleItem {
   category?: string
   cost?: number
   provider?: string
+  imei?: string
+  barcode?: string
 }
 
 interface Product {
@@ -85,6 +87,7 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
               <TableHeader>
                 <TableRow>
                   <TableHead>Producto</TableHead>
+                  <TableHead>IMEI/Serie</TableHead>
                   <TableHead>Cantidad</TableHead>
                   <TableHead>Precio Unitario</TableHead>
                   {user.role === 'admin' && <TableHead>Costo Unitario</TableHead>}
@@ -113,6 +116,10 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
                   return (
                     <TableRow key={`${item.productId}-${index}`}>
                       <TableCell className="font-medium">{item.productName}</TableCell>
+                      <TableCell>
+                        {item.imei && <div>IMEI: {item.imei}</div>}
+                        {item.barcode && <div>S/N: {item.barcode}</div>}
+                      </TableCell>
                       <TableCell>{item.quantity}</TableCell>
                       <TableCell>
                         {isUSD ? (
@@ -173,6 +180,10 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
                 {sale.tradeIn && sale.tradeIn.price > 0 && (
                   <TableRow key="trade-in">
                     <TableCell className="font-medium">Parte de Pago: {sale.tradeIn.name || 'Equipo'}</TableCell>
+                    <TableCell>
+                      {sale.tradeIn.imei && <div>IMEI: {sale.tradeIn.imei}</div>}
+                      {sale.tradeIn.serialNumber && <div>S/N: {sale.tradeIn.serialNumber}</div>}
+                    </TableCell>
                     <TableCell>1</TableCell>
                     <TableCell>
                       {`USD ${Number(sale.tradeIn.price).toFixed(2)}`}


### PR DESCRIPTION
## Summary
- display IMEI/serial numbers for sold products in sales list and detail modal
- hide profit metrics for moderators while allowing them to close cash
- add `Cerrar Caja` button for moderators near quick sale

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b71560aebc832681c20ec083ae7f28