### PR TITLE
feat: track cash withdrawals and fix cellphone totals

### DIFF
--- a/app/dashboard/caja/cierres/page.tsx
+++ b/app/dashboard/caja/cierres/page.tsx
@@ -45,6 +45,11 @@ interface Closure {
   cellphonesCashUSD?: number;
   cellphonesBankARS?: number;
   cellphonesBankUSD?: number;
+  withdrawalsAccCashARS?: number;
+  withdrawalsAccBankARS?: number;
+  withdrawalsCellCashARS?: number;
+  withdrawalsCellBankARS?: number;
+  withdrawals?: any[];
   note?: string;
   sales?: Sale[];
 }
@@ -102,6 +107,11 @@ export default function CashClosuresPage() {
     doc.text(`Dólares: $${cellphonesUSD.toFixed(2)}`, 10, y); y += 10;
     doc.text(`Banco ARS: $${(c.cellphonesBankARS || 0).toFixed(2)}`, 10, y); y += 10;
     doc.text(`Banco USD: $${(c.cellphonesBankUSD || 0).toFixed(2)}`, 10, y); y += 20;
+    const withdrawAcc = (c.withdrawalsAccCashARS || 0) + (c.withdrawalsAccBankARS || 0);
+    const withdrawCell = (c.withdrawalsCellCashARS || 0) + (c.withdrawalsCellBankARS || 0);
+    doc.text('Extracciones', 10, y); y += 10;
+    doc.text(`Accesorios: $${withdrawAcc.toFixed(2)}`, 10, y); y += 10;
+    doc.text(`Celulares: $${withdrawCell.toFixed(2)}`, 10, y); y += 20;
     if (c.note) {
       doc.text('Notas:', 10, y); y += 10;
       doc.text(c.note, 10, y);

--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -44,6 +44,7 @@ import {
   Barcode,
   User,
   Wallet,
+  Banknote,
 } from "lucide-react";
 import { ref, onValue, set, push, remove, update } from "firebase/database";
 import { database } from "@/lib/firebase";
@@ -51,6 +52,7 @@ import { toast } from "sonner";
 import SellProductModal from "@/components/sell-product-modal";
 import TransferProductDialog from "@/components/transfer-product-dialog";
 import QuickSaleDialog from "@/components/quick-sale-dialog";
+import CashWithdrawalDialog from "@/components/cash-withdrawal-dialog";
 import {
   Select,
   SelectContent,
@@ -121,6 +123,7 @@ export default function InventoryPage() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isWithdrawalOpen, setIsWithdrawalOpen] = useState(false);
   const [newProduct, setNewProduct] = useState<NewProduct>({
     name: "",
     brand: "",
@@ -479,42 +482,79 @@ export default function InventoryPage() {
               Venta Rápida
             </Button>
             {user?.role === "moderator" && (
-              <Button
-                onClick={() => router.push("/dashboard/caja")}
-                className="w-full sm:w-auto"
-                variant="secondary"
-              >
-                <Wallet className="mr-2 h-4 w-4" />
-                Cerrar Caja
-              </Button>
+              <>
+                <Button
+                  onClick={() => router.push("/dashboard/caja")}
+                  className="w-full sm:w-auto"
+                  variant="secondary"
+                >
+                  <Wallet className="mr-2 h-4 w-4" />
+                  Cerrar Caja
+                </Button>
+                <Button
+                  onClick={() => {
+                    if (selectedStore === "all") {
+                      toast.error("Seleccione un local", {
+                        description:
+                          "Debe elegir un local antes de registrar extracciones.",
+                      });
+                      return;
+                    }
+                    setIsWithdrawalOpen(true);
+                  }}
+                  className="w-full sm:w-auto"
+                  variant="destructive"
+                >
+                  <Banknote className="mr-2 h-4 w-4" />
+                  Extracción de dinero
+                </Button>
+              </>
             )}
             {user?.role === "admin" && (
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className="w-full sm:w-auto">
-                    <Plus className="mr-2 h-4 w-4" />
-                    Agregar Producto
-                  </Button>
-                </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>Agregar Nuevo Producto</DialogTitle>
-                    <DialogDescription>
-                      Complete los detalles del nuevo producto a agregar al
-                      inventario.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className="grid gap-4 py-4">
-                    <div className="space-y-2">
-                      <Label>Local</Label>
-                      <Input
-                        value={
-                          selectedStore === "local2" ? "Local 2" : "Local 1"
-                        }
-                        disabled
-                      />
-                    </div>
-                    <div className="grid grid-cols-2 gap-4">
+              <>
+                <Button
+                  onClick={() => {
+                    if (selectedStore === "all") {
+                      toast.error("Seleccione un local", {
+                        description:
+                          "Debe elegir un local antes de registrar extracciones.",
+                      });
+                      return;
+                    }
+                    setIsWithdrawalOpen(true);
+                  }}
+                  className="w-full sm:w-auto"
+                  variant="destructive"
+                >
+                  <Banknote className="mr-2 h-4 w-4" />
+                  Extracción de dinero
+                </Button>
+                <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+                  <DialogTrigger asChild>
+                    <Button className="w-full sm:w-auto">
+                      <Plus className="mr-2 h-4 w-4" />
+                      Agregar Producto
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Agregar Nuevo Producto</DialogTitle>
+                      <DialogDescription>
+                        Complete los detalles del nuevo producto a agregar al
+                        inventario.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-4 py-4">
+                      <div className="space-y-2">
+                        <Label>Local</Label>
+                        <Input
+                          value={
+                            selectedStore === "local2" ? "Local 2" : "Local 1"
+                          }
+                          disabled
+                        />
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
                       <div className="space-y-2">
                         <Label htmlFor="name">Nombre</Label>
                         <Input
@@ -713,7 +753,8 @@ export default function InventoryPage() {
                     <Button onClick={handleAddProduct}>Guardar</Button>
                   </DialogFooter>
                 </DialogContent>
-              </Dialog>
+                </Dialog>
+              </>
             )}
           </div>
         </div>
@@ -874,6 +915,11 @@ export default function InventoryPage() {
         isOpen={isQuickSaleOpen}
         onClose={() => setIsQuickSaleOpen(false)}
         store={selectedStore}
+      />
+
+      <CashWithdrawalDialog
+        isOpen={isWithdrawalOpen}
+        onClose={() => setIsWithdrawalOpen(false)}
       />
 
       {editingProduct && user?.role === "admin" && (

--- a/components/cash-withdrawal-dialog.tsx
+++ b/components/cash-withdrawal-dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { ref, push } from "firebase/database";
+import { database } from "@/lib/firebase";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useStore } from "@/hooks/use-store";
+import { toast } from "sonner";
+
+interface CashWithdrawalDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function CashWithdrawalDialog({ isOpen, onClose }: CashWithdrawalDialogProps) {
+  const { selectedStore } = useStore();
+  const [box, setBox] = useState("accessories");
+  const [method, setMethod] = useState("cash");
+  const [amount, setAmount] = useState(0);
+  const [note, setNote] = useState("");
+
+  const reset = () => {
+    setBox("accessories");
+    setMethod("cash");
+    setAmount(0);
+    setNote("");
+  };
+
+  const handleConfirm = async () => {
+    if (selectedStore === "all") {
+      toast.error("Seleccione un local", {
+        description: "Debe elegir un local antes de registrar extracciones.",
+      });
+      return;
+    }
+    if (amount <= 0) {
+      toast.error("Ingrese un monto válido");
+      return;
+    }
+    try {
+      await push(ref(database, "cashWithdrawals"), {
+        box,
+        method,
+        amount,
+        note,
+        timestamp: Date.now(),
+        store: selectedStore,
+      });
+      toast.success("Extracción registrada");
+      onClose();
+      reset();
+    } catch (e) {
+      console.error("Error recording withdrawal", e);
+      toast.error("No se pudo registrar la extracción");
+    }
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+          reset();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Extracción de dinero</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Select value={box} onValueChange={setBox}>
+              <SelectTrigger>
+                <SelectValue placeholder="Caja" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="accessories">Caja de Accesorios</SelectItem>
+                <SelectItem value="cellphones">Caja de Celulares</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Select value={method} onValueChange={setMethod}>
+              <SelectTrigger>
+                <SelectValue placeholder="Método" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="cash">Efectivo</SelectItem>
+                <SelectItem value="transfer">Transferencia</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Input
+              type="number"
+              placeholder="Monto"
+              value={amount}
+              onChange={(e) => setAmount(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Textarea
+              placeholder="Anotaciones"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => { onClose(); reset(); }}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirm}>Confirmar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+


### PR DESCRIPTION
## Summary
- allow registering cash withdrawals with a dedicated dialog
- account for withdrawals and cellphone sales during cash closure
- show withdrawal data in past cash closures

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b756169a408326ab08aee558761cf0