### PR TITLE
feat: add USD cash payment option

### DIFF
--- a/app/dashboard/caja/page.tsx
+++ b/app/dashboard/caja/page.tsx
@@ -232,8 +232,12 @@ export default function CajaPage() {
           accessoryTotalARS += priceInARS;
         }
 
-        if (pm === 'efectivo') {
-          if (currency === 'USD') {
+        if (pm === 'efectivo' || pm === 'efectivo_usd') {
+          if (pm === 'efectivo_usd') {
+            const priceUSD = currency === 'USD' ? price : price / (sale.usdRate || 1);
+            totalCashUSD += priceUSD;
+            if (isCell) cellCashUSD += priceUSD; else accCashUSD += priceUSD;
+          } else if (currency === 'USD') {
             totalCashUSD += price;
             if (isCell) cellCashUSD += price; else accCashUSD += price;
           } else {

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -420,13 +420,15 @@ export default function SalesPage() {
                           <Badge variant="outline">
                             {sale.paymentMethod === "efectivo"
                               ? "Efectivo"
-                              : sale.paymentMethod === "tarjeta"
-                                ? "Tarjeta"
-                                : sale.paymentMethod === "transferencia"
-                                  ? "Transferencia"
-                                  : sale.paymentMethod === "multiple"
-                                    ? "Múltiple"
-                                    : sale.paymentMethod}
+                              : sale.paymentMethod === "efectivo_usd"
+                                ? "Efectivo USD"
+                                : sale.paymentMethod === "tarjeta"
+                                  ? "Tarjeta"
+                                  : sale.paymentMethod === "transferencia"
+                                    ? "Transferencia"
+                                    : sale.paymentMethod === "multiple"
+                                      ? "Múltiple"
+                                      : sale.paymentMethod}
                           </Badge>
                         </TableCell>
                       )}

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -151,6 +151,7 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="efectivo">Efectivo</SelectItem>
+                <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                 <SelectItem value="tarjeta">Tarjeta</SelectItem>
                 <SelectItem value="transferencia">Transferencia</SelectItem>
                 <SelectItem value="multiple">Pago Múltiple</SelectItem>

--- a/components/customer-detail-modal.tsx
+++ b/components/customer-detail-modal.tsx
@@ -195,6 +195,8 @@ export default function CustomerDetailModal({ isOpen, onClose, customer }: Custo
                             <Badge variant="outline">
                               {purchase.paymentMethod === "efectivo"
                                 ? "Efectivo"
+                                : purchase.paymentMethod === "efectivo_usd"
+                                  ? "Efectivo USD"
                                 : purchase.paymentMethod === "tarjeta"
                                   ? "Tarjeta"
                                   : purchase.paymentMethod === "transferencia"

--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -58,6 +58,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
   const [cashAmount, setCashAmount] = useState(0);
   const [transferAmount, setTransferAmount] = useState(0);
   const [cardAmount, setCardAmount] = useState(0);
+  const [usdRate, setUsdRate] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -74,6 +75,16 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
   }, [isOpen]);
 
   useEffect(() => {
+    if (!isOpen) return;
+    const usdRef = ref(database, "config/usdRate");
+    const unsubscribe = onValue(usdRef, (snapshot) => {
+      const val = snapshot.val();
+      setUsdRate(typeof val === "number" ? val : 0);
+    });
+    return () => unsubscribe();
+  }, [isOpen]);
+
+  useEffect(() => {
     if (!isOpen) {
       setSearchTerm("");
       setCart([]);
@@ -81,6 +92,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
       setCashAmount(0);
       setTransferAmount(0);
       setCardAmount(0);
+      setUsdRate(0);
     }
   }, [isOpen]);
 
@@ -203,6 +215,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
           ? { cashAmount, transferAmount, cardAmount }
           : {}),
         store: store === "local2" ? "local2" : "local1",
+        usdRate,
       };
       await set(saleRef, saleData);
 
@@ -357,6 +370,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="efectivo">Efectivo</SelectItem>
+                <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                 <SelectItem value="tarjeta">Tarjeta</SelectItem>
                 <SelectItem value="transferencia">Transferencia</SelectItem>
                 <SelectItem value="multiple">Pago Múltiple</SelectItem>

--- a/components/sale-detail-modal.tsx
+++ b/components/sale-detail-modal.tsx
@@ -214,7 +214,7 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
               </div>
             ) : (
               <div className="text-sm">
-                Método de Pago: <Badge variant="outline">{sale.paymentMethod}</Badge>
+                Método de Pago: <Badge variant="outline">{sale.paymentMethod === "efectivo_usd" ? "Efectivo USD" : sale.paymentMethod}</Badge>
               </div>
             )}
             <div className="text-xl font-bold">

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -747,6 +747,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                       <SelectTrigger><SelectValue/></SelectTrigger>
                       <SelectContent>
                         <SelectItem value="efectivo">Efectivo</SelectItem>
+                        <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                         <SelectItem value="tarjeta">Tarjeta</SelectItem>
                         <SelectItem value="transferencia">Transferencia</SelectItem>
                         <SelectItem value="multiple">Pago Múltiple</SelectItem>


### PR DESCRIPTION
## Summary
- allow quick and regular sales to be paid in USD cash
- capture and store USD rate for quick sales
- update dashboards to display and account for USD cash payments

## Testing
- `pnpm lint`
- `pnpm build` *(fails: missing NEXT_PUBLIC_FIREBASE_APIKEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a3ba0dc8326a443911327b07c86