### PR TITLE
feat: add usd cash to multiple payment

### DIFF
--- a/app/dashboard/caja/page.tsx
+++ b/app/dashboard/caja/page.tsx
@@ -37,6 +37,7 @@ interface Sale {
   items: SaleItem[];
   paymentMethod?: string;
   cashAmount?: number;
+  cashUsdAmount?: number;
   transferAmount?: number;
   cardAmount?: number;
   usdRate?: number;
@@ -258,13 +259,17 @@ export default function CajaPage() {
       if (pm === 'multiple') {
         const saleTotalARS = accessoryTotalARS + cellphoneTotalARS;
         const cash = sale.cashAmount || 0;
+        const cashUSD = sale.cashUsdAmount || 0;
         const bank = (sale.transferAmount || 0) + (sale.cardAmount || 0);
         totalCashARS += cash;
+        totalCashUSD += cashUSD;
         totalBankARS += bank;
         const accRatio = saleTotalARS ? accessoryTotalARS / saleTotalARS : 0;
         const cellRatio = saleTotalARS ? cellphoneTotalARS / saleTotalARS : 0;
         accCashARS += cash * accRatio;
         cellCashARS += cash * cellRatio;
+        accCashUSD += cashUSD * accRatio;
+        cellCashUSD += cashUSD * cellRatio;
         accBankARS += bank * accRatio;
         cellBankARS += bank * cellRatio;
       }

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -44,6 +44,7 @@ interface Sale {
   totalAmount: number
   paymentMethod?: string
   cashAmount?: number
+  cashUsdAmount?: number
   transferAmount?: number
   cardAmount?: number
   [key: string]: any

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -48,12 +48,14 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
   const [isLoading, setIsLoading] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState("efectivo");
   const [cashAmount, setCashAmount] = useState(0);
+  const [cashUsdAmount, setCashUsdAmount] = useState(0);
   const [transferAmount, setTransferAmount] = useState(0);
   const [cardAmount, setCardAmount] = useState(0);
 
   useEffect(() => {
     if (paymentMethod !== "multiple") {
       setCashAmount(0);
+      setCashUsdAmount(0);
       setTransferAmount(0);
       setCardAmount(0);
     }
@@ -69,7 +71,11 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
       const usdRate = usdRateSnapshot.exists() ? usdRateSnapshot.val() : 0;
       const totalARS = (reserve.remainingAmount || 0) * usdRate;
       if (paymentMethod === "multiple") {
-        const sum = cashAmount + transferAmount + cardAmount;
+        const sum =
+          cashAmount +
+          transferAmount +
+          cardAmount +
+          cashUsdAmount * usdRate;
         if (Math.abs(sum - totalARS) > 0.01) {
           toast.error("La suma de los montos no coincide con el total");
           setIsLoading(false);
@@ -93,7 +99,9 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
           provider: reserve.productData?.provider || null,
         }],
         paymentMethod,
-        ...(paymentMethod === "multiple" ? { cashAmount, transferAmount, cardAmount } : {}),
+        ...(paymentMethod === "multiple"
+          ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
+          : {}),
         totalAmount: totalARS, // Se registra el pago del saldo
         usdRate,
         notes: `Venta completada desde reserva #${reserve.id}`,
@@ -159,10 +167,14 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
             </Select>
           </div>
           {paymentMethod === "multiple" && (
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
               <div className="space-y-1">
                 <Label>Monto Efectivo</Label>
                 <Input type="number" value={cashAmount} onChange={(e) => setCashAmount(Number(e.target.value) || 0)} />
+              </div>
+              <div className="space-y-1">
+                <Label>Monto Efectivo USD</Label>
+                <Input type="number" value={cashUsdAmount} onChange={(e) => setCashUsdAmount(Number(e.target.value) || 0)} />
               </div>
               <div className="space-y-1">
                 <Label>Monto Transferencia</Label>

--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -56,6 +56,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
   const [cart, setCart] = useState<CartItem[]>([]);
   const [paymentMethod, setPaymentMethod] = useState("efectivo");
   const [cashAmount, setCashAmount] = useState(0);
+  const [cashUsdAmount, setCashUsdAmount] = useState(0);
   const [transferAmount, setTransferAmount] = useState(0);
   const [cardAmount, setCardAmount] = useState(0);
   const [usdRate, setUsdRate] = useState(0);
@@ -90,6 +91,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
       setCart([]);
       setPaymentMethod("efectivo");
       setCashAmount(0);
+      setCashUsdAmount(0);
       setTransferAmount(0);
       setCardAmount(0);
       setUsdRate(0);
@@ -99,6 +101,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
   useEffect(() => {
     if (paymentMethod !== "multiple") {
       setCashAmount(0);
+      setCashUsdAmount(0);
       setTransferAmount(0);
       setCardAmount(0);
     }
@@ -165,7 +168,11 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
       return;
     }
     if (paymentMethod === "multiple") {
-      const sum = cashAmount + transferAmount + cardAmount;
+      const sum =
+        cashAmount +
+        transferAmount +
+        cardAmount +
+        cashUsdAmount * usdRate;
       if (Math.abs(sum - totalAmount) > 0.01) {
         toast.error("La suma de los montos no coincide con el total");
         return;
@@ -212,7 +219,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
         totalAmount,
         paymentMethod,
         ...(paymentMethod === "multiple"
-          ? { cashAmount, transferAmount, cardAmount }
+          ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
           : {}),
         store: store === "local2" ? "local2" : "local1",
         usdRate,
@@ -378,13 +385,21 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
             </Select>
           </div>
           {paymentMethod === "multiple" && (
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
               <div className="space-y-1">
                 <Label>Monto Efectivo</Label>
                 <Input
                   type="number"
                   value={cashAmount}
                   onChange={(e) => setCashAmount(Number(e.target.value) || 0)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label>Monto Efectivo USD</Label>
+                <Input
+                  type="number"
+                  value={cashUsdAmount}
+                  onChange={(e) => setCashUsdAmount(Number(e.target.value) || 0)}
                 />
               </div>
               <div className="space-y-1">

--- a/components/sale-detail-modal.tsx
+++ b/components/sale-detail-modal.tsx
@@ -20,6 +20,7 @@ interface Sale {
   totalAmount: number
   paymentMethod?: string
   cashAmount?: number
+  cashUsdAmount?: number
   transferAmount?: number
   cardAmount?: number
   receiptNumber?: string
@@ -209,6 +210,7 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
                   Método de Pago: <Badge variant="outline">Múltiple</Badge>
                 </div>
                 <div>Efectivo: ${ (sale.cashAmount ?? 0).toFixed(2) }</div>
+                <div>Efectivo USD: ${ (sale.cashUsdAmount ?? 0).toFixed(2) }</div>
                 <div>Transferencia: ${ (sale.transferAmount ?? 0).toFixed(2) }</div>
                 <div>Tarjeta: ${ (sale.cardAmount ?? 0).toFixed(2) }</div>
               </div>

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -63,6 +63,7 @@ interface Sale {
     items: any[]; // Se mantiene flexible para los items de la venta
     paymentMethod: string;
     cashAmount?: number;
+    cashUsdAmount?: number;
     transferAmount?: number;
     cardAmount?: number;
     totalAmount: number;
@@ -112,6 +113,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
   const [customer, setCustomer] = useState({ name: "", dni: "", phone: "", email: "" })
   const [paymentMethod, setPaymentMethod] = useState("efectivo")
   const [cashAmount, setCashAmount] = useState(0)
+  const [cashUsdAmount, setCashUsdAmount] = useState(0)
   const [transferAmount, setTransferAmount] = useState(0)
   const [cardAmount, setCardAmount] = useState(0)
   const [completedSale, setCompletedSale] = useState<Sale | null>(null)
@@ -142,6 +144,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
   useEffect(() => {
     if (paymentMethod !== "multiple") {
       setCashAmount(0)
+      setCashUsdAmount(0)
       setTransferAmount(0)
       setCardAmount(0)
     }
@@ -366,7 +369,11 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
         return;
     }
     if (paymentMethod === "multiple") {
-        const sum = cashAmount + transferAmount + cardAmount;
+        const sum =
+            cashAmount +
+            transferAmount +
+            cardAmount +
+            cashUsdAmount * usdRate;
         if (Math.abs(sum - finalTotal) > 0.01) {
             toast.error("La suma de los montos no coincide con el total");
             return;
@@ -477,7 +484,9 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                 cost: item.cost ?? 0,
             })),
             paymentMethod,
-            ...(paymentMethod === "multiple" ? { cashAmount, transferAmount, cardAmount } : {}),
+            ...(paymentMethod === "multiple"
+                ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
+                : {}),
             totalAmount: finalTotal,
             tradeIn: isTradeIn ? tradeInProduct : null,
             usdRate,
@@ -755,10 +764,14 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                     </Select>
                   </div>
                   {paymentMethod === "multiple" && (
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                    <div className="grid grid-cols-1 sm:grid-cols-4 gap-2">
                       <div className="space-y-1">
                         <Label>Monto Efectivo</Label>
                         <Input type="number" value={cashAmount} onChange={(e) => setCashAmount(Number(e.target.value) || 0)} />
+                      </div>
+                      <div className="space-y-1">
+                        <Label>Monto Efectivo USD</Label>
+                        <Input type="number" value={cashUsdAmount} onChange={(e) => setCashUsdAmount(Number(e.target.value) || 0)} />
                       </div>
                       <div className="space-y-1">
                         <Label>Monto Transferencia</Label>


### PR DESCRIPTION
## Summary
- allow USD cash in multi-payment options
- display USD cash info in sale details
- update cash metrics for mixed payments

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b75db6ea808326a8fb0d530424810a