### PR TITLE
feat: add USDT handling and move withdrawal control

### DIFF
--- a/app/dashboard/caja/cierres/page.tsx
+++ b/app/dashboard/caja/cierres/page.tsx
@@ -21,6 +21,7 @@ interface SaleItem {
 interface Sale {
   id: string;
   items: SaleItem[];
+  [key: string]: any;
 }
 
 interface Closure {
@@ -34,6 +35,7 @@ interface Closure {
   gananciasLimpias: number;
   cantidadCelularesVendidos: number;
   dineroTotalUSD: number;
+  dineroTotalUSDT?: number;
   gananciasLimpiasUSD: number;
   dineroTotalEfectivoUSD: number;
   dineroTotalBancoUSD: number;
@@ -45,10 +47,13 @@ interface Closure {
   cellphonesCashUSD?: number;
   cellphonesBankARS?: number;
   cellphonesBankUSD?: number;
+  cellphonesUsdt?: number;
   withdrawalsAccCashARS?: number;
   withdrawalsAccBankARS?: number;
   withdrawalsCellCashARS?: number;
   withdrawalsCellBankARS?: number;
+  withdrawalsCellCashUSD?: number;
+  withdrawalsCellUsdt?: number;
   withdrawals?: any[];
   note?: string;
   sales?: Sale[];
@@ -105,10 +110,11 @@ export default function CashClosuresPage() {
     doc.text('Celulares', 10, y); y += 10;
     doc.text(`Efectivo ARS: $${(c.cellphonesCashARS || 0).toFixed(2)}`, 10, y); y += 10;
     doc.text(`Dólares: $${cellphonesUSD.toFixed(2)}`, 10, y); y += 10;
+    doc.text(`USDT: ${(c.cellphonesUsdt || 0).toFixed(2)}`, 10, y); y += 10;
     doc.text(`Banco ARS: $${(c.cellphonesBankARS || 0).toFixed(2)}`, 10, y); y += 10;
     doc.text(`Banco USD: $${(c.cellphonesBankUSD || 0).toFixed(2)}`, 10, y); y += 20;
     const withdrawAcc = (c.withdrawalsAccCashARS || 0) + (c.withdrawalsAccBankARS || 0);
-    const withdrawCell = (c.withdrawalsCellCashARS || 0) + (c.withdrawalsCellBankARS || 0);
+    const withdrawCell = (c.withdrawalsCellCashARS || 0) + (c.withdrawalsCellBankARS || 0) + (c.withdrawalsCellCashUSD || 0) + (c.withdrawalsCellUsdt || 0);
     doc.text('Extracciones', 10, y); y += 10;
     doc.text(`Accesorios: $${withdrawAcc.toFixed(2)}`, 10, y); y += 10;
     doc.text(`Celulares: $${withdrawCell.toFixed(2)}`, 10, y); y += 20;
@@ -144,6 +150,7 @@ export default function CashClosuresPage() {
               <p>Productos vendidos: {c.cantidadProductosVendidos}</p>
               <p>Dinero total ARS: ${c.dineroTotal.toFixed(2)}</p>
               <p>Dinero total USD: ${c.dineroTotalUSD.toFixed(2)}</p>
+              {c.dineroTotalUSDT && <p>Dinero total USDT: {c.dineroTotalUSDT.toFixed(2)}</p>}
               {c.note && <p>Nota: {c.note}</p>}
               <details className="mt-2">
                 <summary>Ver detalles</summary>

--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -44,7 +44,6 @@ import {
   Barcode,
   User,
   Wallet,
-  Banknote,
 } from "lucide-react";
 import { ref, onValue, set, push, remove, update } from "firebase/database";
 import { database } from "@/lib/firebase";
@@ -52,7 +51,6 @@ import { toast } from "sonner";
 import SellProductModal from "@/components/sell-product-modal";
 import TransferProductDialog from "@/components/transfer-product-dialog";
 import QuickSaleDialog from "@/components/quick-sale-dialog";
-import CashWithdrawalDialog from "@/components/cash-withdrawal-dialog";
 import {
   Select,
   SelectContent,
@@ -123,7 +121,6 @@ export default function InventoryPage() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isWithdrawalOpen, setIsWithdrawalOpen] = useState(false);
   const [newProduct, setNewProduct] = useState<NewProduct>({
     name: "",
     brand: "",
@@ -491,44 +488,10 @@ export default function InventoryPage() {
                   <Wallet className="mr-2 h-4 w-4" />
                   Cerrar Caja
                 </Button>
-                <Button
-                  onClick={() => {
-                    if (selectedStore === "all") {
-                      toast.error("Seleccione un local", {
-                        description:
-                          "Debe elegir un local antes de registrar extracciones.",
-                      });
-                      return;
-                    }
-                    setIsWithdrawalOpen(true);
-                  }}
-                  className="w-full sm:w-auto"
-                  variant="destructive"
-                >
-                  <Banknote className="mr-2 h-4 w-4" />
-                  Extracción de dinero
-                </Button>
               </>
             )}
             {user?.role === "admin" && (
               <>
-                <Button
-                  onClick={() => {
-                    if (selectedStore === "all") {
-                      toast.error("Seleccione un local", {
-                        description:
-                          "Debe elegir un local antes de registrar extracciones.",
-                      });
-                      return;
-                    }
-                    setIsWithdrawalOpen(true);
-                  }}
-                  className="w-full sm:w-auto"
-                  variant="destructive"
-                >
-                  <Banknote className="mr-2 h-4 w-4" />
-                  Extracción de dinero
-                </Button>
                 <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
                   <DialogTrigger asChild>
                     <Button className="w-full sm:w-auto">
@@ -915,11 +878,6 @@ export default function InventoryPage() {
         isOpen={isQuickSaleOpen}
         onClose={() => setIsQuickSaleOpen(false)}
         store={selectedStore}
-      />
-
-      <CashWithdrawalDialog
-        isOpen={isWithdrawalOpen}
-        onClose={() => setIsWithdrawalOpen(false)}
       />
 
       {editingProduct && user?.role === "admin" && (

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -33,6 +33,7 @@ interface Sale {
   totalAmount: number;
   customerId?: string;
   store?: string;
+  usdtAmount?: number;
 }
 
 interface Product {

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -47,6 +47,7 @@ interface Sale {
   cashUsdAmount?: number
   transferAmount?: number
   cardAmount?: number
+  usdtAmount?: number
   [key: string]: any
 }
 
@@ -429,7 +430,9 @@ export default function SalesPage() {
                                     ? "Transferencia"
                                     : sale.paymentMethod === "multiple"
                                       ? "Múltiple"
-                                      : sale.paymentMethod}
+                                      : sale.paymentMethod === "transferencia_usdt"
+                                        ? "Transferencia USDT"
+                                        : sale.paymentMethod}
                           </Badge>
                         </TableCell>
                       )}

--- a/components/cash-withdrawal-dialog.tsx
+++ b/components/cash-withdrawal-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ref, push } from "firebase/database";
 import { database } from "@/lib/firebase";
 import { Button } from "@/components/ui/button";
@@ -34,6 +34,12 @@ export default function CashWithdrawalDialog({ isOpen, onClose }: CashWithdrawal
   const [method, setMethod] = useState("cash");
   const [amount, setAmount] = useState(0);
   const [note, setNote] = useState("");
+
+  useEffect(() => {
+    if (box !== "cellphones" && (method === "cash_usd" || method === "usdt")) {
+      setMethod("cash");
+    }
+  }, [box, method]);
 
   const reset = () => {
     setBox("accessories");
@@ -104,7 +110,13 @@ export default function CashWithdrawalDialog({ isOpen, onClose }: CashWithdrawal
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="cash">Efectivo</SelectItem>
+                {box === "cellphones" && (
+                  <SelectItem value="cash_usd">Efectivo USD</SelectItem>
+                )}
                 <SelectItem value="transfer">Transferencia</SelectItem>
+                {box === "cellphones" && (
+                  <SelectItem value="usdt">USDT</SelectItem>
+                )}
               </SelectContent>
             </Select>
           </div>

--- a/components/complete-reserve-modal.tsx
+++ b/components/complete-reserve-modal.tsx
@@ -101,7 +101,9 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
         paymentMethod,
         ...(paymentMethod === "multiple"
           ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
-          : {}),
+          : paymentMethod === "transferencia_usdt"
+            ? { usdtAmount: totalARS / usdRate }
+            : {}),
         totalAmount: totalARS, // Se registra el pago del saldo
         usdRate,
         notes: `Venta completada desde reserva #${reserve.id}`,
@@ -162,6 +164,7 @@ export default function CompleteReserveModal({ isOpen, onClose, reserve, onReser
                 <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                 <SelectItem value="tarjeta">Tarjeta</SelectItem>
                 <SelectItem value="transferencia">Transferencia</SelectItem>
+                <SelectItem value="transferencia_usdt">Transferencia USDT</SelectItem>
                 <SelectItem value="multiple">Pago Múltiple</SelectItem>
               </SelectContent>
             </Select>

--- a/components/customer-detail-modal.tsx
+++ b/components/customer-detail-modal.tsx
@@ -205,7 +205,9 @@ export default function CustomerDetailModal({ isOpen, onClose, customer }: Custo
                                       ? "Mercado Pago"
                                       : purchase.paymentMethod === "multiple"
                                         ? "Múltiple"
-                                        : purchase.paymentMethod}
+                                        : purchase.paymentMethod === "transferencia_usdt"
+                                          ? "Transferencia USDT"
+                                          : purchase.paymentMethod}
                             </Badge>
                           </TableCell>
                         </TableRow>

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -24,6 +24,7 @@ import {
   Image,
   Wallet,
   Smartphone,
+  Banknote,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { getAuth, signOut } from "firebase/auth"
@@ -49,6 +50,8 @@ import MobileMenu from "@/components/mobile-menu"
 import { useStore } from "@/hooks/use-store"
 import { Reserve } from "@/components/complete-reserve-modal"
 import ChatWidget from '@/components/ChatWidget' // <<<--- AÑADIDO
+import CashWithdrawalDialog from "@/components/cash-withdrawal-dialog"
+import { toast } from "sonner"
 
 interface DashboardLayoutProps {
   children: React.ReactNode
@@ -109,6 +112,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [expiringReserves, setExpiringReserves] = useState(false);
 
   const { selectedStore, setSelectedStore } = useStore();
+  const [isWithdrawalOpen, setIsWithdrawalOpen] = useState(false);
 
   useEffect(() => {
     const fetchDolarBlue = async () => {
@@ -253,6 +257,25 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               </DropdownMenuContent>
             </DropdownMenu>
 
+            {(user.role === "admin" || user.role === "moderator") && (
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  if (selectedStore === "all") {
+                    toast.error("Seleccione un local", {
+                      description: "Debe elegir un local antes de registrar extracciones.",
+                    });
+                    return;
+                  }
+                  setIsWithdrawalOpen(true);
+                }}
+                className="hidden sm:flex"
+              >
+                <Banknote className="mr-2 h-4 w-4" />
+                Extracción
+              </Button>
+            )}
+
             <div className="hidden sm:flex items-center gap-2">
                 <span className="font-semibold text-sm text-blue-600">Dólar Blue:</span>
                 {isDolarLoading ? (
@@ -296,6 +319,11 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             </DropdownMenu>
           </div>
         </header>
+
+        <CashWithdrawalDialog
+          isOpen={isWithdrawalOpen}
+          onClose={() => setIsWithdrawalOpen(false)}
+        />
 
         <div className="flex flex-1">
           <aside className="group sticky top-16 hidden h-[calc(100vh-4rem)] md:flex flex-col border-r bg-white w-16 hover:w-64 transition-all duration-300 ease-in-out">

--- a/components/quick-sale-dialog.tsx
+++ b/components/quick-sale-dialog.tsx
@@ -220,7 +220,9 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
         paymentMethod,
         ...(paymentMethod === "multiple"
           ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
-          : {}),
+          : paymentMethod === "transferencia_usdt"
+            ? { usdtAmount: totalAmount / usdRate }
+            : {}),
         store: store === "local2" ? "local2" : "local1",
         usdRate,
       };
@@ -380,6 +382,7 @@ export default function QuickSaleDialog({ isOpen, onClose, store }: QuickSaleDia
                 <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                 <SelectItem value="tarjeta">Tarjeta</SelectItem>
                 <SelectItem value="transferencia">Transferencia</SelectItem>
+                <SelectItem value="transferencia_usdt">Transferencia USDT</SelectItem>
                 <SelectItem value="multiple">Pago Múltiple</SelectItem>
               </SelectContent>
             </Select>

--- a/components/sale-detail-modal.tsx
+++ b/components/sale-detail-modal.tsx
@@ -25,6 +25,7 @@ interface Sale {
   cardAmount?: number
   receiptNumber?: string
   usdRate?: number
+  usdtAmount?: number
   [key: string]: any
 }
 
@@ -216,7 +217,7 @@ export default function SaleDetailModal({ isOpen, onClose, sale, products, user 
               </div>
             ) : (
               <div className="text-sm">
-                Método de Pago: <Badge variant="outline">{sale.paymentMethod === "efectivo_usd" ? "Efectivo USD" : sale.paymentMethod}</Badge>
+                Método de Pago: <Badge variant="outline">{sale.paymentMethod === "efectivo_usd" ? "Efectivo USD" : sale.paymentMethod === "transferencia_usdt" ? "Transferencia USDT" : sale.paymentMethod}</Badge>
               </div>
             )}
             <div className="text-xl font-bold">

--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -69,6 +69,7 @@ interface Sale {
     totalAmount: number;
     tradeIn: any;
     usdRate: number;
+    usdtAmount?: number;
     pointsUsed?: number;
     pointsEarned?: number;
     pointsAccumulated?: number;
@@ -486,7 +487,9 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
             paymentMethod,
             ...(paymentMethod === "multiple"
                 ? { cashAmount, cashUsdAmount, transferAmount, cardAmount }
-                : {}),
+                : paymentMethod === "transferencia_usdt"
+                  ? { usdtAmount: finalTotal / usdRate }
+                  : {}),
             totalAmount: finalTotal,
             tradeIn: isTradeIn ? tradeInProduct : null,
             usdRate,
@@ -759,6 +762,7 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                         <SelectItem value="efectivo_usd">Efectivo USD</SelectItem>
                         <SelectItem value="tarjeta">Tarjeta</SelectItem>
                         <SelectItem value="transferencia">Transferencia</SelectItem>
+                        <SelectItem value="transferencia_usdt">Transferencia USDT</SelectItem>
                         <SelectItem value="multiple">Pago Múltiple</SelectItem>
                       </SelectContent>
                     </Select>

--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -36,6 +36,8 @@ interface Sale {
   pointsAccumulated?: number;
   pointsPaused?: boolean;
   store?: 'local1' | 'local2';
+  paymentMethod?: string;
+  usdtAmount?: number;
 }
 
 interface Repair {


### PR DESCRIPTION
## Summary
- Move cash withdrawal action next to store selector for admins and moderators
- Track USD and USDT withdrawals from cellphone box
- Support USDT transfers in sales and reflect totals in cash register

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76146a8808326814e5748ce779476