### PR TITLE
Make sales info cards respect date filter

### DIFF
--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -227,12 +227,12 @@ export default function SalesPage() {
   }, [products, cellphonesOnly])
 
   useEffect(() => {
-    if (salesFilteredByType.length > 0) {
-      calculateSalesStats(salesFilteredByType)
+    if (filteredByDate.length > 0) {
+      calculateSalesStats(filteredByDate)
     } else {
       calculateSalesStats([])
     }
-  }, [salesFilteredByType, calculateSalesStats])
+  }, [filteredByDate, calculateSalesStats])
 
   const filteredSales = filteredByDate.filter(
     (sale) =>


### PR DESCRIPTION
## Summary
- Recalculate sales statistics using the date-filtered dataset so information cards respond to day/week/all selections

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b77625293883269fe1b74415624c51