### PR TITLE
Fix navigation for cellphone categories

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -338,7 +338,16 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 <CollapsibleContent className="space-y-1 pt-1 hidden group-hover:block">
                   <Link href="/dashboard/inventory" className={cn("flex items-center rounded-md py-2 pl-12 pr-3 text-sm text-slate-700 hover:bg-slate-100", pathname === "/dashboard/inventory" && !currentCategory && "bg-slate-200 font-semibold")}>Todos</Link>
                   {categories.map((category) => (
-                    <Link key={category} href={`/dashboard/inventory?category=${encodeURIComponent(category)}`} className={cn("flex items-center rounded-md py-2 pl-12 pr-3 text-sm text-slate-700 hover:bg-slate-100", currentCategory === category && "bg-slate-200 font-semibold")}>{category}</Link>
+                    <Link
+                      key={category}
+                      href={{ pathname: "/dashboard/inventory", query: { category } }}
+                      className={cn(
+                        "flex items-center rounded-md py-2 pl-12 pr-3 text-sm text-slate-700 hover:bg-slate-100",
+                        currentCategory === category && "bg-slate-200 font-semibold"
+                      )}
+                    >
+                      {category}
+                    </Link>
                   ))}
                 </CollapsibleContent>
               </Collapsible>

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -111,18 +111,18 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
                   )}>
                     Todos los productos
                   </Link>
-                  {categories.map(cat => (
-                      <Link
-                        key={cat.id}
-                        href={`/dashboard/inventory?category=${encodeURIComponent(cat.name)}`}
-                        onClick={handleLinkClick}
-                        className={cn(
-                          "block rounded-md p-2 text-sm hover:bg-slate-100",
-                          currentCategory === cat.name && "bg-slate-200"
-                        )}
-                      >
-                          {cat.name}
-                      </Link>
+                  {categories.map((cat) => (
+                    <Link
+                      key={cat.id}
+                      href={{ pathname: "/dashboard/inventory", query: { category: cat.name } }}
+                      onClick={handleLinkClick}
+                      className={cn(
+                        "block rounded-md p-2 text-sm hover:bg-slate-100",
+                        currentCategory === cat.name && "bg-slate-200"
+                      )}
+                    >
+                      {cat.name}
+                    </Link>
                   ))}
               </CollapsibleContent>
             </Collapsible>


### PR DESCRIPTION
## Summary
- fix inventory menu links for categories with spaces
- ensure mobile menu links to inventory categories correctly

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6603bc48326ae5c69a6b3d33845