### PR TITLE
Fix bank deposit calculation in cost simulator

### DIFF
--- a/app/dashboard/simulator/page.tsx
+++ b/app/dashboard/simulator/page.tsx
@@ -67,7 +67,7 @@ export default function CostSimulatorPage() {
     const subtotal = net + vatAmount + systemCharge;
     const catAmount = subtotal * catRate;
     const totalClient = subtotal + catAmount;
-    const bankAmount = net - net * promoRate;
+    const bankAmount = net - systemFee - net * promoRate;
     const installments = parseInt(selectedInstallment, 10);
     const perInstallment = totalClient / installments;
 


### PR DESCRIPTION
## Summary
- adjust net bank amount to subtract system fee before crediting

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea7b98008326ba16d11cdabb84cf