### PR TITLE
Adjust simulator to keep net amount after bank fees

### DIFF
--- a/app/dashboard/simulator/page.tsx
+++ b/app/dashboard/simulator/page.tsx
@@ -60,14 +60,13 @@ export default function CostSimulatorPage() {
     const promoRate = (instCfg.commerceCost || 0) / 100;
 
     const vatAmount = net * vatRate;
-    const systemFeeBase = net + vatAmount;
-    const systemFee = systemFeeBase * systemRate;
-    const systemFeeVat = systemFee * vatRate;
-    const systemCharge = systemFee + systemFeeVat;
-    const subtotal = net + vatAmount + systemCharge;
-    const catAmount = subtotal * catRate;
-    const totalClient = subtotal + catAmount;
-    const bankAmount = net - systemFee - net * promoRate;
+    const desiredAmount = net + vatAmount;
+    const baseAmount =
+      desiredAmount / (1 - systemRate * (1 + vatRate));
+    const systemCharge = baseAmount - desiredAmount;
+    const catAmount = baseAmount * catRate;
+    const totalClient = baseAmount + catAmount;
+    const bankAmount = desiredAmount - net * promoRate;
     const installments = parseInt(selectedInstallment, 10);
     const perInstallment = totalClient / installments;
 


### PR DESCRIPTION
## Summary
- use reverse calculation so simulator returns an amount that preserves net+VAT after 4.9%+IVA bank fee

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9ed4d160c8326b6f5436b348353d5