### PR TITLE
feat: highlight POS amount

### DIFF
--- a/app/dashboard/simulator/page.tsx
+++ b/app/dashboard/simulator/page.tsx
@@ -36,6 +36,7 @@ export default function CostSimulatorPage() {
           bank: number;
           vat: number;
           system: number;
+          posnet: number;
           installments: number;
           perInstallment: number;
         }
@@ -75,6 +76,7 @@ export default function CostSimulatorPage() {
       bank: bankAmount,
       vat: vatAmount,
       system: systemCharge,
+      posnet: baseAmount,
       installments,
       perInstallment,
     });
@@ -107,6 +109,10 @@ export default function CostSimulatorPage() {
         <Button onClick={calculate}>Calcular</Button>
         {result && (
           <div className="space-y-2">
+            <p className="text-xl font-semibold">
+              Monto a pasar en el posnet: ${" "}
+              {result.posnet.toFixed(2)}
+            </p>
             <p>IVA: ${result.vat.toFixed(2)}</p>
             <p>
               Cargo del sistema (4.9% + IVA): $


### PR DESCRIPTION
## Summary
- show net + VAT + system fee as POS amount in cost simulator
- emphasize POS amount in larger text for quick reference

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9effe4fe48326aa86a3b3ceb4b05d