### PR TITLE
Ocultar accesos no deseados en menú de celulares

### DIFF
--- a/app/dashboard/mobile/page.tsx
+++ b/app/dashboard/mobile/page.tsx
@@ -52,6 +52,7 @@ import {
 import { ref, onValue } from "firebase/database";
 import { database } from "@/lib/firebase";
 import { useAuth } from "@/hooks/use-auth";
+import { useStore } from "@/hooks/use-store";
 import { Reserve } from "@/components/complete-reserve-modal";
 
 interface Category {
@@ -99,6 +100,7 @@ export default function MobilePage() {
   const router = useRouter();
   const isMobile = useMobile();
   const { user, loading: authLoading } = useAuth();
+  const { selectedStore } = useStore();
 
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [deviceInfo, setDeviceInfo] = useState({
@@ -483,6 +485,15 @@ export default function MobilePage() {
     },
   ];
 
+  const filteredQuickActions = quickActions.filter((action) => {
+    if (selectedStore === "local2") {
+      if (action.title === "Ventas" || action.title === "Simulador de Costos") {
+        return false;
+      }
+    }
+    return true;
+  });
+
   return (
     <DashboardLayout>
       <div className="space-y-6 p-4">
@@ -587,7 +598,7 @@ export default function MobilePage() {
             </CardHeader>
           </Card>
 
-          {quickActions.map((action) => (
+          {filteredQuickActions.map((action) => (
             <Card
               key={action.title}
               className="cursor-pointer transition-shadow hover:shadow-lg"

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -231,7 +231,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       <div className="flex min-h-screen w-full flex-col bg-slate-50">
         <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b bg-white px-4 md:px-6">
           <div className="flex items-center gap-2">
-            <MobileMenu userRole={user.role} />
+            <MobileMenu userRole={user.role} selectedStore={selectedStore} />
             <Link href="/dashboard" className="hidden md:flex items-center gap-2 font-semibold">
               <Package className="h-6 w-6" />
               <span className="text-xl">iMarket</span>
@@ -354,7 +354,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
               <NavItem href="/dashboard/low-stock" icon={AlertTriangle} label="Bajo Stock" active={pathname === "/dashboard/low-stock"} />
 
-              <NavItem href="/dashboard/sales" icon={ShoppingCart} label="Ventas" active={pathname === "/dashboard/sales" && currentSalesType !== 'celulares'} />
+              {selectedStore !== 'local2' && (
+                <NavItem
+                  href="/dashboard/sales"
+                  icon={ShoppingCart}
+                  label="Ventas"
+                  active={pathname === "/dashboard/sales" && currentSalesType !== 'celulares'}
+                />
+              )}
               <NavItem href="/dashboard/sales?type=celulares" icon={Smartphone} label="Ventas de Celulares" active={pathname === "/dashboard/sales" && currentSalesType === 'celulares'} />
 
               <Collapsible open={isReservesOpen} onOpenChange={setIsReservesOpen} className="w-full">
@@ -375,7 +382,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 <NavItem href="/dashboard/customers" icon={Users} label="Clientes" active={pathname === "/dashboard/customers"} />
               )}
 
-              <NavItem href="/dashboard/simulator" icon={Calculator} label="Simulador de Costos" active={pathname === "/dashboard/simulator"} />
+              {selectedStore !== 'local2' && (
+                <NavItem
+                  href="/dashboard/simulator"
+                  icon={Calculator}
+                  label="Simulador de Costos"
+                  active={pathname === "/dashboard/simulator"}
+                />
+              )}
 
             </nav>
           </aside>

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -11,8 +11,11 @@ import { cn } from "@/lib/utils"
 import { ref, onValue } from "firebase/database"
 import { database } from "@/lib/firebase"
 
+type StoreOption = 'all' | 'local1' | 'local2'
+
 interface MobileMenuProps {
   userRole: string
+  selectedStore: StoreOption
 }
 
 interface Category {
@@ -20,7 +23,7 @@ interface Category {
   name: string;
 }
 
-export default function MobileMenu({ userRole }: MobileMenuProps) {
+export default function MobileMenu({ userRole, selectedStore }: MobileMenuProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentCategory = searchParams.get('category');
@@ -54,6 +57,13 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
     { href: "/dashboard/reserves", label: "Reservas", icon: ShoppingCart, active: pathname === "/dashboard/reserves", role: ["admin", "moderator"] },
     { href: "/dashboard/customers", label: "Clientes", icon: Users, active: pathname === "/dashboard/customers", role: ["admin"] },
   ];
+
+  const filteredRoutes = mainRoutes.filter((route) => {
+    if (selectedStore === 'local2' && route.href === "/dashboard/sales") {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <div className="md:hidden">
@@ -128,7 +138,7 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
             </Collapsible>
 
             {/* Resto de las rutas filtradas por rol */}
-            {mainRoutes.filter(route => route.label !== 'Dashboard').map((route) => (
+            {filteredRoutes.filter(route => route.label !== 'Dashboard').map((route) => (
               route.role.includes(userRole) && (
                 <Link
                   key={route.href}


### PR DESCRIPTION
## Summary
- oculté la opción de ventas generales y el simulador de costos en la barra lateral cuando se gestiona el local de celulares
- actualicé el menú móvil y las acciones rápidas del panel móvil para respetar la misma restricción

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd762327d0832698a287518371e0ed