### PR TITLE
Add cost simulator entry to mobile dashboard menu

### DIFF
--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
-import { Home, Package, ShoppingCart, Users, Wrench, ChevronDown, LayoutDashboard, AlertTriangle } from "lucide-react"
+import { Home, Package, ShoppingCart, Users, Wrench, ChevronDown, LayoutDashboard, AlertTriangle, Calculator } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -52,6 +52,7 @@ export default function MobileMenu({ userRole }: MobileMenuProps) {
     { href: "/dashboard/sales", label: "Ventas", icon: ShoppingCart, active: pathname === "/dashboard/sales", role: ["admin", "moderator"] },
     { href: "/dashboard/repairs", label: "Reparaciones", icon: Wrench, active: pathname === "/dashboard/repairs", role: ["admin", "moderator"] },
     { href: "/dashboard/reserves", label: "Reservas", icon: ShoppingCart, active: pathname === "/dashboard/reserves", role: ["admin", "moderator"] },
+    { href: "/dashboard/simulator", label: "Simulador de Costos", icon: Calculator, active: pathname === "/dashboard/simulator", role: ["admin", "moderator"] },
     { href: "/dashboard/customers", label: "Clientes", icon: Users, active: pathname === "/dashboard/customers", role: ["admin"] },
   ];
 


### PR DESCRIPTION
## Summary
- add the calculator icon import used by the cost simulator link
- include the cost simulator route in the mobile dashboard navigation so it matches desktop access

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a5c0d1348326adea3525417eff0b