### PR TITLE
Ajusta cálculo del simulador para ingresos brutos

### DIFF
--- a/app/dashboard/simulator/page.tsx
+++ b/app/dashboard/simulator/page.tsx
@@ -119,15 +119,16 @@ export default function CostSimulatorPage() {
     const promoRate = (instCfg.commerceCost || 0) / 100;
 
     const vatAmount = net * vatRate;
-    const desiredAmount = net + vatAmount;
     const grossIncomeRate = (config.grossIncome ?? 0) / 100;
+    const grossIncomeBase = net + vatAmount;
+    const grossIncomeAmount = grossIncomeBase * grossIncomeRate;
+    const desiredAmount = grossIncomeBase + grossIncomeAmount;
     const baseAmount =
       desiredAmount / (1 - systemRate * (1 + vatRate));
     const systemCharge = baseAmount - desiredAmount;
     const catAmount = baseAmount * catRate;
     const totalClient = baseAmount + catAmount;
-    const grossIncomeAmount = desiredAmount * grossIncomeRate;
-    const bankAmount = desiredAmount - net * promoRate - grossIncomeAmount;
+    const bankAmount = desiredAmount - net * promoRate;
     const installments = parseInt(selectedInstallment, 10);
     const perInstallment = totalClient / installments;
 


### PR DESCRIPTION
## Summary
- suma el cargo de ingresos brutos al monto objetivo antes de calcular el importe a pasar por posnet
- actualiza el monto bancario para reflejar neto + IVA + ingresos brutos manteniendo el detalle de impuestos

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b04bc880832687dd91b440c7eb06