### PR TITLE
Agregar cálculo automático del restante a transferir en pago múltiple

### DIFF
--- a/components/sell-product-modal.tsx
+++ b/components/sell-product-modal.tsx
@@ -717,6 +717,16 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
     () => multiplePaymentTotal - finalTotal,
     [multiplePaymentTotal, finalTotal]
   );
+  const remainingAmountWithoutTransfer = useMemo(
+    () => finalTotal - (cashAmount + cardAmount + cashUsdAmount * usdRate),
+    [finalTotal, cashAmount, cardAmount, cashUsdAmount, usdRate]
+  );
+  const suggestedTransferAmount = useMemo(() => {
+    if (transferUsdRate <= 0 || usdRate <= 0) return 0;
+    const remainingToCover = Math.max(0, remainingAmountWithoutTransfer);
+    const transferNeeded = (remainingToCover / usdRate) * transferUsdRate;
+    return Math.round(transferNeeded * 100) / 100;
+  }, [remainingAmountWithoutTransfer, transferUsdRate, usdRate]);
 
   const startSignatureSession = useCallback(async (sale: Sale) => {
     setSignatureSessionError(null)
@@ -1435,33 +1445,54 @@ export default function SellProductModal({ isOpen, onClose, product, onProductSo
                     </Select>
                   </div>
                   {paymentMethod === "multiple" && (
-                    <div className="grid grid-cols-1 sm:grid-cols-5 gap-2">
-                      <div className="space-y-1">
-                        <Label>Monto Efectivo</Label>
-                        <Input type="number" value={cashAmount} onChange={(e) => setCashAmount(Number(e.target.value) || 0)} />
+                    <div className="space-y-2">
+                      <div className="grid grid-cols-1 sm:grid-cols-5 gap-2">
+                        <div className="space-y-1">
+                          <Label>Monto Efectivo</Label>
+                          <Input type="number" value={cashAmount} onChange={(e) => setCashAmount(Number(e.target.value) || 0)} />
+                        </div>
+                        <div className="space-y-1">
+                          <Label>Monto Efectivo USD</Label>
+                          <Input type="number" value={cashUsdAmount} onChange={(e) => setCashUsdAmount(Number(e.target.value) || 0)} />
+                        </div>
+                        <div className="space-y-1">
+                          <Label>Monto Transferencia</Label>
+                          <Input type="number" value={transferAmount} onChange={(e) => setTransferAmount(Number(e.target.value) || 0)} />
+                        </div>
+                        <div className="space-y-1">
+                          <Label>Cotización Transferencia</Label>
+                          <Input
+                            type="number"
+                            value={transferUsdRate}
+                            placeholder="Ej: 1200"
+                            onChange={(e) => setTransferUsdRate(Number(e.target.value) || 0)}
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label>Monto Tarjeta</Label>
+                          <Input type="number" value={cardAmount} onChange={(e) => setCardAmount(Number(e.target.value) || 0)} />
+                        </div>
                       </div>
-                      <div className="space-y-1">
-                        <Label>Monto Efectivo USD</Label>
-                        <Input type="number" value={cashUsdAmount} onChange={(e) => setCashUsdAmount(Number(e.target.value) || 0)} />
-                      </div>
-                      <div className="space-y-1">
-                        <Label>Monto Transferencia</Label>
-                        <Input type="number" value={transferAmount} onChange={(e) => setTransferAmount(Number(e.target.value) || 0)} />
-                      </div>
-                      <div className="space-y-1">
-                        <Label>Cotización Transferencia</Label>
-                        <Input
-                          type="number"
-                          value={transferUsdRate}
-                          disabled={transferAmount <= 0}
-                          placeholder="Ej: 1200"
-                          onChange={(e) => setTransferUsdRate(Number(e.target.value) || 0)}
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label>Monto Tarjeta</Label>
-                        <Input type="number" value={cardAmount} onChange={(e) => setCardAmount(Number(e.target.value) || 0)} />
-                      </div>
+                      {transferUsdRate > 0 && usdRate > 0 && (
+                        <div className="flex items-center gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTransferAmount(suggestedTransferAmount)}
+                          >
+                            Calcular restante a transferir
+                          </Button>
+                          <span className="text-xs text-muted-foreground">
+                            Sugerido: {formatCurrency(suggestedTransferAmount)} por transferencia.
+                          </span>
+                        </div>
+                      )}
+                      {remainingAmountWithoutTransfer <= 0 && (
+                        <p className="text-xs text-emerald-600">
+                          Ya se cubrió el total sin transferencia.
+                        </p>
+                      )}
                     </div>
                   )}
                   {paymentMethod === "multiple" && transferAmount > 0 && transferUsdRate > 0 && (


### PR DESCRIPTION
### Motivation
- Permitir calcular automáticamente cuánto falta transferir cuando el vendedor cargó la cotización USD por transferencia y parte del pago se hizo en efectivo (incluyendo efectivo en USD). 

### Description
- Añadí el cálculo de `remainingAmountWithoutTransfer` y `suggestedTransferAmount` usando `usdRate` y `transferUsdRate` para determinar el monto de transferencia necesario en la cotización del vendedor. 
- Permití ingresar `Cotización Transferencia` aun cuando `Monto Transferencia` sea 0 para poder calcular primero la cotización y luego aplicar el cálculo automático. 
- Agregué un botón `Calcular restante a transferir` que completa `Monto Transferencia` con el valor sugerido basado en la cotización ingresada. 
- Mostré un mensaje en verde cuando el total ya está cubierto sin necesitar transferencia para evitar errores por diferencia de montos.

### Testing
- Ejecuté `pnpm -s exec eslint components/sell-product-modal.tsx` y no arrojó errores (quedó 1 warning preexistente de hooks). 
- Ejecuté `pnpm -s exec tsc --noEmit` y la compilación falla por errores de tipado preexistentes en varios archivos del proyecto fuera del ámbito de este cambio, por lo que `tsc` no terminó exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf0de2d2a483268f0ce5a78881b044)