### PR TITLE
Treat new/used phones as individual items during transfers

### DIFF
--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -791,17 +791,22 @@ export default function InventoryPage() {
   const handleTransferProduct = async (product: Product, quantity: number) => {
     const targetStore = product.store === "local1" ? "local2" : "local1";
     const currentStock = product.stock || 0;
+    const isIndividualPhone =
+      product.category === "Celulares Nuevos" ||
+      product.category === "Celulares Usados";
 
     try {
       const productRef = ref(database, `products/${product.id}`);
-      const existing = products.find(
-        (p) =>
-          p.store === targetStore &&
-          p.name === product.name &&
-          p.brand === product.brand &&
-          p.model === product.model &&
-          p.category === product.category
-      );
+      const existing = isIndividualPhone
+        ? undefined
+        : products.find(
+            (p) =>
+              p.store === targetStore &&
+              p.name === product.name &&
+              p.brand === product.brand &&
+              p.model === product.model &&
+              p.category === product.category,
+          );
 
       const shouldDeleteRecord = shouldRemoveProductFromInventory(
         product.category,


### PR DESCRIPTION
### Motivation
- Evitar que al trasladar equipos categorizados como `Celulares Nuevos` o `Celulares Usados` se fusionen con un registro existente en el local destino cuando en realidad son dispositivos distintos (diferente IMEI/serie/precio). 

### Description
- Añadida la variable `isIndividualPhone` en `app/dashboard/inventory/page.tsx` para detectar si un producto pertenece a `Celulares Nuevos` o `Celulares Usados`. 
- Cuando `isIndividualPhone` es `true` se evita buscar un registro "existing" en el destino y por lo tanto no se consolida stock por nombre/marca/modelo/categoría para estos equipos. 
- El comportamiento de consolidación por coincidencia permanece igual para el resto de categorías.

### Testing
- Ejecuté `npm run lint`, que se ejecutó pero falló por errores de lint preexistentes en otros archivos (`components/catalog-ad.tsx`), los cuales son ajenos a este cambio; no se detectaron fallos relacionados con la modificación en `app/dashboard/inventory/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56e5904a08326801102a3c323ce78)