### PR TITLE
Fix top promo marquee overflow and overlap behavior

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -157,6 +157,22 @@ body {
   }
 }
 
+@keyframes top-marquee-scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+@layer utilities {
+  .top-marquee-track {
+    animation: top-marquee-scroll 28s linear infinite;
+    will-change: transform;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/components/public-top-bar.tsx
+++ b/components/public-top-bar.tsx
@@ -16,6 +16,9 @@ export default function PublicTopBar({
   desktopContent,
   mobileContent,
 }: PublicTopBarProps) {
+  const marqueeText = marqueeItems.join(" • ")
+  const estimatedDurationInSeconds = Math.min(Math.max(marqueeText.length * 0.2, 18), 72)
+
   return (
     <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-xl shadow-black/10">
       <div className="hidden w-full items-center justify-between gap-4 md:flex md:flex-nowrap">
@@ -23,8 +26,11 @@ export default function PublicTopBar({
       </div>
       <div className="mt-3 flex items-center gap-3">
         <div className="flex-1 overflow-hidden rounded-full border border-white/10 bg-slate-950/60">
-          <div className="flex w-full">
-            <div className="flex min-w-full shrink-0 animate-marquee items-center justify-start gap-6 whitespace-nowrap px-4 py-2 text-sm text-slate-200">
+          <div
+            className="top-marquee-track flex w-max items-center"
+            style={{ animationDuration: `${estimatedDurationInSeconds}s` }}
+          >
+            <div className="flex shrink-0 items-center justify-start gap-6 whitespace-nowrap px-4 py-2 text-sm text-slate-200">
               {marqueeItems.map((item, index) => (
                 <span key={`offer-primary-${index}`} className="flex items-center gap-2">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" />
@@ -32,10 +38,7 @@ export default function PublicTopBar({
                 </span>
               ))}
             </div>
-            <div
-              className="flex min-w-full shrink-0 animate-marquee items-center justify-start gap-6 whitespace-nowrap px-4 py-2 text-sm text-slate-200"
-              style={{ animationDelay: "12s" }}
-            >
+            <div className="flex shrink-0 items-center justify-start gap-6 whitespace-nowrap px-4 py-2 text-sm text-slate-200">
               {marqueeItems.map((item, index) => (
                 <span key={`offer-secondary-${index}`} className="flex items-center gap-2">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-300" />


### PR DESCRIPTION
### Motivation
- The top promotional marquee clipped and sometimes overwrote text when many promotions were loaded, producing broken or partially missing messages. 
- The goal is to provide a stable, continuous scrolling track and a readable speed for long combined messages so promotions are always shown correctly.

### Description
- Reworked the marquee markup in `components/public-top-bar.tsx` to render a single continuous track (`top-marquee-track`) that contains duplicated content blocks to produce a seamless loop. 
- Added a runtime calculation for the marquee duration using `marqueeItems.join(" • ")` and `estimatedDurationInSeconds` (bounded between 18s and 72s) so longer text slows the scroll for readability. 
- Added global keyframes `top-marquee-scroll` and a utility `.top-marquee-track` in `app/globals.css` to animate `translateX(-50%)` for a smooth infinite loop and applied `will-change: transform` for better performance.

### Testing
- Ran the linter with `npm run lint`, which reported pre-existing lint errors (including rule-of-hooks errors in `components/catalog-ad.tsx`) and warnings in other files; these failures are unrelated to the marquee changes. 
- No additional automated tests were added; the visual behavior was adjusted via CSS/JS changes only and should be validated in the browser across expected content lengths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b354704208326ab7bf27f6e26b959)