### PR TITLE
Agregar catálogo público “Dispositivos Android” (no descuenta stock)

### DIFF
--- a/app/catalogo/[tipo]/ClientPage.tsx
+++ b/app/catalogo/[tipo]/ClientPage.tsx
@@ -132,6 +132,12 @@ const BASE_CATALOG_TYPES: Record<string, CatalogType> = {
     accent: "from-sky-500/20 to-blue-500/5",
     kind: "new",
   },
+  "dispositivos-android": {
+    key: "dispositivos-android",
+    title: "Dispositivos Android",
+    accent: "from-amber-500/20 to-orange-500/10",
+    kind: "new",
+  },
   usados: {
     key: "usados",
     title: "Celulares Usados",

--- a/app/catalogo/[tipo]/page.tsx
+++ b/app/catalogo/[tipo]/page.tsx
@@ -5,7 +5,12 @@ import PublicStockClient from "./ClientPage"
 export const dynamicParams = true
 
 export function generateStaticParams() {
-  return [{ tipo: "nuevos" }, { tipo: "usados" }, { tipo: "gaming-audio" }]
+  return [
+    { tipo: "nuevos" },
+    { tipo: "dispositivos-android" },
+    { tipo: "usados" },
+    { tipo: "gaming-audio" },
+  ]
 }
 
 export default function PublicStockPage({ params }: { params: { tipo: string } }) {

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -843,7 +843,12 @@ export default function SettingsPage() {
       toast.error("Ingresá un nombre válido para generar el enlace.");
       return;
     }
-    if (key === "nuevos" || key === "usados" || key === "gaming-audio") {
+    if (
+      key === "nuevos" ||
+      key === "dispositivos-android" ||
+      key === "usados" ||
+      key === "gaming-audio"
+    ) {
       toast.error("Ese nombre ya está reservado para un catálogo existente.");
       return;
     }
@@ -1421,6 +1426,7 @@ export default function SettingsPage() {
   const catalogAdAllowMultiple = catalogAdType !== "video";
   const catalogOptions = [
     { key: "nuevos", label: "Catálogo de nuevos" },
+    { key: "dispositivos-android", label: "Dispositivos Android" },
     ...publicCatalogs.map((catalog) => ({
       key: catalog.key,
       label: catalog.name,
@@ -1433,6 +1439,7 @@ export default function SettingsPage() {
     { key: "landing", label: "Selección de catálogo (superior)" },
     { key: "landingBottom", label: "Selección de catálogo (inferior)" },
     { key: "nuevos", label: "Catálogo de nuevos" },
+    { key: "dispositivos-android", label: "Catálogo de dispositivos Android" },
     { key: "usados", label: "Catálogo de usados" },
     { key: "gaming-audio", label: "Catálogo de gaming y audio" },
     ...publicCatalogs.map((catalog) => ({

--- a/components/public-access-landing.tsx
+++ b/components/public-access-landing.tsx
@@ -28,6 +28,13 @@ const baseLandingOptions = [
     icon: Sparkles,
   },
   {
+    title: "Dispositivos Android",
+    description: "Mirá equipos Android cargados desde configuración, sin impacto en el stock.",
+    href: "/catalogo/dispositivos-android",
+    accent: "from-amber-500/20 via-orange-400/5 to-transparent",
+    icon: Smartphone,
+  },
+  {
     title: "Celulares usados",
     description: "Revisá el stock de equipos usados certificados y listos para entrega.",
     href: "/catalogo/usados",


### PR DESCRIPTION
### Motivation
- Añadir un catálogo público llamado `Dispositivos Android` cuyos equipos se carguen desde Configuración y no afecten el stock, para mostrar precios en la web.

### Description
- Se incorporó un nuevo tipo base en `BASE_CATALOG_TYPES` con key `dispositivos-android` y `kind: "new"` para reutilizar la lógica de catálogo de nuevos (`app/catalogo/[tipo]/ClientPage.tsx`).
- Habilité la generación estática de la ruta `/catalogo/dispositivos-android` en `app/catalogo/[tipo]/page.tsx` para que exista como página pública directa.
- Añadí la opción en la landing pública para mostrar `Dispositivos Android` como una selección destacada (`components/public-access-landing.tsx`).
- Actualicé la pantalla de Configuración para reservar el slug `dispositivos-android`, incluirlo en `catalogOptions` y en `catalogAdLocations` para poder cargar equipos en ese catálogo sin tocar stock (`app/dashboard/settings/page.tsx`).

### Testing
- Ejecuté `npm run lint` y el comando finalizó con errores por lints preexistentes en archivos no modificados por este PR (por ejemplo `components/catalog-ad.tsx`), por lo que la verificación automática de lint falló.
- No se ejecutaron pruebas unitarias automatizadas adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7d861d748326992bfa889eda48b2)