### PR TITLE
Actualizar copy marketinero en card Android y textos intro de catálogos

### DIFF
--- a/app/catalogo/[tipo]/ClientPage.tsx
+++ b/app/catalogo/[tipo]/ClientPage.tsx
@@ -1285,10 +1285,10 @@ export default function PublicStockClient({ params }: { params: { tipo: string }
       : inStock.length
   const catalogItemsLabel = isGamingAudioCatalog ? "productos" : "equipos"
   const catalogIntro = isNewCatalog
-    ? "Expertos en tecnología a tu alcance. 🏠 Te damos la bienvenida a nuestra selección de equipos nuevos. Mostramos solo la información técnica esencial para garantizar la transparencia y la seguridad de cada dispositivo."
+    ? "Descubrí tu próximo equipo ideal ✨ Modelos que enamoran, promos irresistibles y toda la onda tech para que elijas el que va con tu estilo."
     : isGamingAudioCatalog
-      ? "Potenciá tu experiencia gamer y musical. 🎧 Descubrí parlantes, auriculares y accesorios JBL con disponibilidad en tiempo real."
-      : "La mejor tecnología a un precio increíble. 📱 Explorá nuestros usados seleccionados, ideales para quienes buscan rendimiento y ahorro. Resguardamos los datos sensibles de cada equipo para ofrecerte una compra protegida y confiable."
+      ? "Subí el volumen de tu experiencia 🎧 Parlantes, auriculares y accesorios que transforman cada partida y cada canción en otro nivel."
+      : "Renová tu celu gastando menos 🔥 Encontrá usados seleccionados con gran rendimiento, excelente precio y oportunidades que vuelan."
 
   const topBarDesktopContent = (
     <>

--- a/components/public-access-landing.tsx
+++ b/components/public-access-landing.tsx
@@ -29,7 +29,7 @@ const baseLandingOptions = [
   },
   {
     title: "Dispositivos Android",
-    description: "Mirá equipos Android cargados desde configuración, sin impacto en el stock.",
+    description: "Descubrí equipos Android que te van a encantar: diseño, potencia y ofertas para elegir el tuyo hoy.",
     href: "/catalogo/dispositivos-android",
     accent: "from-amber-500/20 via-orange-400/5 to-transparent",
     icon: Smartphone,


### PR DESCRIPTION
### Motivation
- Hacer los textos públicos más comerciales y atractivos para clientes, reemplazando el tono técnico por copy marketinero en las vistas de landing y catálogos. 
- Unificar el enfoque de comunicación para los catálogos `new`, `gaming-audio` y `used` y mejorar la presentación de la card de `Dispositivos Android`.

### Description
- Reemplacé la descripción de la card de Android en `components/public-access-landing.tsx` dentro de `baseLandingOptions` por un copy más llamativo. 
- Actualicé la variable `catalogIntro` en `app/catalogo/[tipo]/ClientPage.tsx` para el catálogo `new` con un texto marketinero y eliminé la referencia al bloque técnico anterior. 
- También reescribí los textos introductorios para `gaming-audio` y `used` en `app/catalogo/[tipo]/ClientPage.tsx` con mensajes comerciales más directos.

### Testing
- Ejecuté lint puntualmente sobre los archivos modificados con `next lint --file components/public-access-landing.tsx --file app/catalogo/[tipo]/ClientPage.tsx`. 
- Resultado del lint: sin warnings ni errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c822899fc8326a590f80ab3d8d274)