### PR TITLE
Agregar card para acceder a equipos Android cargados desde Configuración

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { Check, ChevronsUpDown, Copy, Loader2, PlusCircle, Smartphone, Trash, UploadCloud, X } from "lucide-react"
+import { Check, ChevronsUpDown, Copy, ExternalLink, Loader2, PlusCircle, Smartphone, Trash, UploadCloud, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 import { ref, onValue, set, push, remove, get, update } from "firebase/database"
@@ -1435,6 +1435,9 @@ export default function SettingsPage() {
   const catalogOptionsByKey = new Map(
     catalogOptions.map((option) => [option.key, option.label])
   );
+  const androidCatalogItems = newCatalogItems.filter(
+    (item) => (item.catalogKey ?? "nuevos") === "dispositivos-android"
+  );
   const catalogAdLocations = [
     { key: "landing", label: "Selección de catálogo (superior)" },
     { key: "landingBottom", label: "Selección de catálogo (inferior)" },
@@ -2231,6 +2234,56 @@ export default function SettingsPage() {
                         >
                           <Trash className="h-4 w-4" />
                         </Button>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Equipos Android cargados</CardTitle>
+              <CardDescription>
+                Accedé rápido a los equipos que cargaste en el catálogo de dispositivos Android.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">Total de equipos Android cargados</p>
+                  <p className="text-2xl font-semibold">{androidCatalogItems.length}</p>
+                </div>
+                <a
+                  href="/catalogo/dispositivos-android"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full sm:w-auto"
+                >
+                  <Button type="button" variant="outline" className="w-full sm:w-auto">
+                    Ver catálogo Android
+                    <ExternalLink className="ml-2 h-4 w-4" />
+                  </Button>
+                </a>
+              </div>
+              <Separator />
+              <ScrollArea className="h-56">
+                <div className="space-y-2">
+                  {androidCatalogItems.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-muted-foreground">
+                      No hay equipos Android cargados todavía.
+                    </p>
+                  ) : (
+                    androidCatalogItems.map((item) => (
+                      <div key={item.id} className="rounded-md border p-3">
+                        <p className="font-medium">{item.name}</p>
+                        <div className="text-xs text-muted-foreground">
+                          {typeof item.price === "number"
+                            ? `Precio: ${item.price}`
+                            : "Precio: sin definir"}
+                          {item.status ? ` · ${item.status}` : ""}
+                        </div>
                       </div>
                     ))
                   )}


### PR DESCRIPTION
### Motivation
- Facilitar el acceso y la gestión de los equipos que se cargan en el catálogo `dispositivos-android` desde la pantalla de `Configuración` sin tener que navegar manualmente hasta la vista pública del catálogo.

### Description
- Se agregó la importación del ícono `ExternalLink` y una nueva variable `androidCatalogItems` que filtra `newCatalogItems` por `catalogKey === "dispositivos-android"` en `app/dashboard/settings/page.tsx`.
- Se añadió una nueva `Card` titulada "Equipos Android cargados" que muestra el total de equipos, un botón que abre `/catalogo/dispositivos-android` en una nueva pestaña y un listado resumido con nombre, precio y estado.
- Los cambios son únicamente UI dentro de `Configuración` y no modifican la estructura de datos ni la lógica de guardado existente.

### Testing
- Ejecuté `npm run lint` (Next.js linter) y la ejecución falló debido a errores de lint previos en otros archivos (por ejemplo `components/catalog-ad.tsx`), y no por los cambios introducidos en `settings/page.tsx`.
- La nueva UI fue añadida y el archivo `app/dashboard/settings/page.tsx` fue comiteado correctamente sin introducir errores nuevos reportados por el linter en el contexto mostrado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c84eb2cbc8326969951c99462c081)