### PR TITLE
Fix Android catalog selection in settings

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -2158,21 +2158,41 @@ export default function SettingsPage() {
                 </div>
                 <div className="space-y-2">
                   <Label>Catálogo</Label>
-                  <Select
-                    value={selectedNewCatalogKey}
-                    onValueChange={(value) => setSelectedNewCatalogKey(value)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Elegí el catálogo" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {catalogOptions.map((option) => (
-                        <SelectItem key={option.key} value={option.key}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant={selectedNewCatalogKey === "nuevos" ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => setSelectedNewCatalogKey("nuevos")}
+                      >
+                        Catálogo de nuevos
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={selectedNewCatalogKey === "dispositivos-android" ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => setSelectedNewCatalogKey("dispositivos-android")}
+                      >
+                        Dispositivos Android
+                      </Button>
+                    </div>
+                    <Select
+                      value={selectedNewCatalogKey}
+                      onValueChange={(value) => setSelectedNewCatalogKey(value)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Elegí el catálogo" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {catalogOptions.map((option) => (
+                          <SelectItem key={option.key} value={option.key}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="new-catalog-price">Precio</Label>


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia al elegir el catálogo al agregar equipos nuevos para que sea posible seleccionar explícitamente el catálogo de `dispositivos-android` y evitar bloqueos al cargar dispositivos Android.

### Description
- Añadí botones de acción rápida para `Catálogo de nuevos` y `Dispositivos Android` en la sección `Catálogo de equipos nuevos` y mantuve el `Select` con todas las opciones para cubrir catálogos personalizados; los botones solo actualizan `selectedNewCatalogKey` para cambiar la selección.
- Cambio aplicado en `app/dashboard/settings/page.tsx` conservando la lógica de guardado que emplea `selectedNewCatalogKey` al crear el nuevo elemento.

### Testing
- Ejecuté `pnpm -s lint`, que reportó fallos por errores de lint preexistentes en archivos no relacionados (por ejemplo `components/catalog-ad.tsx`), por lo que el proceso terminó con error aunque el cambio en `settings/page.tsx` quedó aplicado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6fceec1c83268eac3b728caea56d)