### PR TITLE
Eliminar botón 'Ver catálogo Android' en Configuración

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { Check, ChevronsUpDown, Copy, ExternalLink, Loader2, PlusCircle, Smartphone, Trash, UploadCloud, X } from "lucide-react"
+import { Check, ChevronsUpDown, Copy, Loader2, PlusCircle, Smartphone, Trash, UploadCloud, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 import { ref, onValue, set, push, remove, get, update } from "firebase/database"
@@ -2262,12 +2262,6 @@ export default function SettingsPage() {
                 </div>
               </div>
               <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
-                <a href="/catalogo/dispositivos-android" target="_blank" rel="noopener noreferrer">
-                  <Button type="button" variant="outline">
-                    Ver catálogo Android
-                    <ExternalLink className="ml-2 h-4 w-4" />
-                  </Button>
-                </a>
                 <Button
                   onClick={() =>
                     handleAddNewCatalogItem("dispositivos-android", {


### PR DESCRIPTION
### Motivation
- El botón de acceso rápido “Ver catálogo Android” estaba duplicado/innecesario en la sección de configuración y dejaba la interfaz descuidada, por lo que se busca simplificarla manteniendo la acción principal de agregar Android al catálogo.

### Description
- Eliminé el bloque del enlace y botón `Ver catálogo Android` en `app/dashboard/settings/page.tsx` y eliminé la importación no usada de `ExternalLink` desde `lucide-react`.

### Testing
- Ejecuté `pnpm -s exec eslint app/dashboard/settings/page.tsx` y la verificación pasó; se reportó un warning preexistente de `react-hooks/exhaustive-deps` no relacionado con este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7a4c7f58832697a9aa1272d0d6b6)