### PR TITLE
feat(settings): agregar botón para eliminar equipos Android del catálogo

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -2284,14 +2284,27 @@ export default function SettingsPage() {
                     </p>
                   ) : (
                     androidCatalogItems.map((item) => (
-                      <div key={item.id} className="rounded-md border p-3">
-                        <p className="font-medium">{item.name}</p>
-                        <div className="text-xs text-muted-foreground">
-                          {typeof item.price === "number"
-                            ? `Precio: ${item.price}`
-                            : "Precio: sin definir"}
-                          {item.status ? ` · ${item.status}` : ""}
+                      <div
+                        key={item.id}
+                        className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div>
+                          <p className="font-medium">{item.name}</p>
+                          <div className="text-xs text-muted-foreground">
+                            {typeof item.price === "number"
+                              ? `Precio: ${item.price}`
+                              : "Precio: sin definir"}
+                            {item.status ? ` · ${item.status}` : ""}
+                          </div>
                         </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive"
+                          onClick={() => handleRemoveNewCatalogItem(item.id)}
+                        >
+                          <Trash className="h-4 w-4" />
+                        </Button>
                       </div>
                     ))
                   )}


### PR DESCRIPTION
### Motivation
- Permitir eliminar individualmente equipos Android cargados en el catálogo de configuración cuando dejan de estar disponibles o tienen precio incorrecto. 

### Description
- Actualicé `app/dashboard/settings/page.tsx` para usar el mismo layout de fila que el catálogo de iPhone y agregar un área de acción por ítem. 
- Añadí un botón por cada item Android que llama al handler existente `handleRemoveNewCatalogItem(item.id)` para eliminar solamente ese registro de `config/newPhones`. 
- El cambio mantiene el comportamiento de catálogo y no afecta el stock real ni el flujo de dinero invertido. 

### Testing
- Ejecuté `npm run lint` y la tarea falló por errores preexistentes en otros archivos (`components/catalog-ad.tsx`), sin introducir nuevos errores en la sección modificada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10611319908326b332923c4282ed51)