### PR TITLE
Mostrar ajuste USD del administrador en catálogo público (usuarios no autenticados)

### DIFF
--- a/app/catalogo/[tipo]/ClientPage.tsx
+++ b/app/catalogo/[tipo]/ClientPage.tsx
@@ -903,10 +903,24 @@ export default function PublicStockClient({ params }: { params: { tipo: string }
 
   useEffect(() => {
     const adjustmentRef = ref(database, "config/usdRateAdjustment")
-    const unsubscribeAdjustment = onValue(adjustmentRef, (snapshot) => {
-      const value = snapshot.val()
+
+    const syncAdjustment = (value: unknown) => {
       setUsdRateAdjustment(typeof value === "number" && Number.isFinite(value) ? value : 0)
-    })
+    }
+
+    const unsubscribeAdjustment = onValue(
+      adjustmentRef,
+      (snapshot) => {
+        syncAdjustment(snapshot.val())
+      },
+      async (error) => {
+        console.warn("No se pudo leer config/usdRateAdjustment por Firebase SDK:", error)
+        const publicAdjustment = await fetchPublicRealtimeValue<unknown>("config/usdRateAdjustment")
+        syncAdjustment(publicAdjustment)
+      },
+    )
+
+    fetchPublicRealtimeValue<unknown>("config/usdRateAdjustment").then(syncAdjustment)
 
     return () => unsubscribeAdjustment()
   }, [])


### PR DESCRIPTION
### Motivation
- El catálogo debe aplicar el ajuste de cotización USD configurado por el administrador a todos los visitantes, estén o no autenticados.
- En contextos no autenticados la lectura directa por el SDK de Firebase puede fallar y dejar el ajuste en `0`, por lo que hace falta un fallback público.

### Description
- Modificado `app/catalogo/[tipo]/ClientPage.tsx` para añadir un helper `syncAdjustment` que normaliza y aplica el valor de ajuste antes de llamar a `setUsdRateAdjustment`.
- Actualizada la suscripción `onValue` a `config/usdRateAdjustment` para incluir un callback de error que hace `console.warn` y obtiene el valor público con `fetchPublicRealtimeValue("config/usdRateAdjustment")` como fallback.
- Añadida una lectura pública inmediata con `fetchPublicRealtimeValue("config/usdRateAdjustment")` al montar el componente para evitar que visitantes no autenticados vean temporalmente ajuste `0`.

### Testing
- Ejecutado `pnpm lint`, que devuelve error por lints preexistentes en archivos no relacionados; no se introdujeron errores nuevos atribuibles a este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17671b57dc8326b18588074388f1af)